### PR TITLE
Copy default.xml to char_name.xml into profiles folder

### DIFF
--- a/profanity.rb
+++ b/profanity.rb
@@ -149,7 +149,7 @@ PORT                        = (Opts.port                || 8000).to_i
 HOST                        = (Opts.host                || "127.0.0.1")
 DEFAULT_COLOR_ID            = (Opts.color_id            || 7).to_i            
 DEFAULT_BACKGROUND_COLOR_ID = (Opts.background_color_id || 0).to_i
-SETTINGS_FILENAME           = Settings.file(Opts.char.downcase + ".xml") if Opts.char
+SETTINGS_FILENAME           = Settings.profile(Opts.char.downcase + ".xml") if Opts.char
 
 def add_prompt(window, prompt_text, cmd="")
   window.add_string("#{prompt_text}#{cmd}", [ h={ :start => 0, :end => (prompt_text.length + cmd.length), :fg => '555555' } ])

--- a/settings/settings.rb
+++ b/settings/settings.rb
@@ -1,14 +1,14 @@
 module Settings
   @lock = Mutex.new
 
-  APP_DIR = Dir.home + "/.profanity"
+  APP_DIR = File.expand_path(File.dirname($0))
 	##
 	## setup app dir
 	##
-	FileUtils.mkdir_p APP_DIR
+	FileUtils.mkdir_p APP_DIR + "/debug"
 
 	def self.file(path)
-		APP_DIR + "/" + path
+		APP_DIR + "/debug/" + path
 	end
 
   def self.read(file)
@@ -21,4 +21,21 @@ module Settings
     bin = Settings.read(file)
     REXML::Document.new(bin).root
   end
+  
+  def self.copy_file(char)
+    path = APP_DIR + "/templates"
+    orig = path + "/default.xml"
+    dest = path + "/" + char
+  
+    File.write(dest, File.read(orig)) if !path.include?(dest)
+       
+    dest
+      
+  end
+  
+  
+  
+  
+ 
+  
 end

--- a/settings/settings.rb
+++ b/settings/settings.rb
@@ -1,14 +1,14 @@
 module Settings
   @lock = Mutex.new
 
-  APP_DIR = Dir.home + "/.profanity"
+  APP_DIR = File.expand_path(File.dirname($0))
 	##
 	## setup app dir
 	##
-	FileUtils.mkdir_p APP_DIR
+	FileUtils.mkdir_p APP_DIR + "/debug"
 
 	def self.file(path)
-		APP_DIR + "/" + path
+		APP_DIR + "/debug/" + path
 	end
 
   def self.read(file)
@@ -21,4 +21,17 @@ module Settings
     bin = Settings.read(file)
     REXML::Document.new(bin).root
   end
+  
+  def self.profile(char)
+    path = APP_DIR + "/templates"
+    orig = path + "/default.xml"
+    dest = path + "/" + char
+
+    File.write(dest, File.read(orig)) if !File.file?(dest)
+       
+    dest
+      
+  end
+  
+
 end

--- a/settings/settings.rb
+++ b/settings/settings.rb
@@ -1,14 +1,14 @@
 module Settings
   @lock = Mutex.new
 
-  APP_DIR = File.expand_path(File.dirname($0))
+  APP_DIR = Dir.home + "/.profanity"
 	##
 	## setup app dir
 	##
-	FileUtils.mkdir_p APP_DIR + "/debug"
+	FileUtils.mkdir_p APP_DIR
 
 	def self.file(path)
-		APP_DIR + "/debug/" + path
+		APP_DIR + "/" + path
 	end
 
   def self.read(file)
@@ -21,21 +21,4 @@ module Settings
     bin = Settings.read(file)
     REXML::Document.new(bin).root
   end
-  
-  def self.copy_file(char)
-    path = APP_DIR + "/templates"
-    orig = path + "/default.xml"
-    dest = path + "/" + char
-  
-    File.write(dest, File.read(orig)) if !path.include?(dest)
-       
-    dest
-      
-  end
-  
-  
-  
-  
- 
-  
 end

--- a/settings/settings.rb
+++ b/settings/settings.rb
@@ -6,7 +6,8 @@ module Settings
 	## setup app dir
 	##
 	FileUtils.mkdir_p APP_DIR + "/debug"
-
+	FileUtils.mkdir_p APP_DIR + "/profiles"
+	
 	def self.file(path)
 		APP_DIR + "/debug/" + path
 	end
@@ -23,9 +24,8 @@ module Settings
   end
   
   def self.profile(char)
-    path = APP_DIR + "/templates"
-    orig = path + "/default.xml"
-    dest = path + "/" + char
+    orig = APP_DIR + "/templates/default.xml"
+    dest = APP_DIR + "/profiles/" + char
 
     File.write(dest, File.read(orig)) if !File.file?(dest)
        


### PR DESCRIPTION
Checks for the character .xml file present in the templates folder. If not there it copies the default.xml into the folder. This change keeps all the files in the profanityFE folder tree.

This also creates a folder for debug files and places them there instead of having them spread out. 