### PR TITLE
Update Opts from Module to Class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+gem 'pry'
+gem 'pry-nav'
 group :development do
-  gem "rspec"
   gem 'rubocop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,46 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    coderay (1.1.3)
+    json (2.8.1)
+    language_server-protocol (3.17.0.3)
+    method_source (1.1.0)
+    parallel (1.26.3)
+    parser (3.3.6.0)
+      ast (~> 2.4.1)
+      racc
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-nav (1.0.0)
+      pry (>= 0.9.10, < 0.15)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    regexp_parser (2.9.2)
+    rubocop (1.68.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.34.1)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.6.0)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  pry
+  pry-nav
+  rubocop
+
+BUNDLED WITH
+   2.5.16

--- a/util/opts.rb
+++ b/util/opts.rb
@@ -1,5 +1,28 @@
-module Opts
+class Opts
   FLAG_PREFIX = "--"
+  attr_reader :port, :char, :host, :default_color_id, :default_background_color_id, :template
+
+  def initialize(command_line_args)
+    config = parse_config(command_line_args)
+  
+    @port = config.fetch('port', 8000).to_i
+    @char = config['char']
+    @host = config.fetch('host', '127.0.0.1')
+    @default_color_id = config.fetch('default-color-id', 7).to_i
+    @default_background_color_id = config.fetch('default-background-color-id', 0).to_i
+    @template = config['template']
+  end
+
+  def parse_config(command_line_args)
+    command_line_args.each_with_object({}) do |arg, config|
+      key, value = arg.split('=', 2) # Use split with limit to avoid extra splits
+      config[key.gsub(/[-–—]/, '')] = value
+    end
+  end
+
+  def links
+    nil
+  end
 
   def self.parse_command(h, c)
     h[c.to_sym] = true
@@ -14,26 +37,5 @@ module Opts
 
       h[name.to_sym] = val.size == 1 ? val.first : val
     end
-  end
-
-  def self.parse(args = ARGV)
-    config = OpenStruct.new
-    if args.size > 0
-      config = OpenStruct.new(**args.reduce(Hash.new) do |h, v|
-                                  if v.start_with?(FLAG_PREFIX)
-                                    parse_flag(h, v)
-                                  else
-                                    parse_command(h, v)
-                                  end
-                                  h
-                                end)
-    end
-    config
-  end
-
-  PARSED = parse()
-
-  def self.method_missing(method, *args)
-    PARSED.send(method, *args)
   end
 end


### PR DESCRIPTION
Update Opts
- Change it from a module to a class
- replace the parse method with a prase_config to reflect
  the intention a bit more. Also we have simplified the parsing.
- Use Hash.fetch to fetch values from the hash with default values
- Update all references of Opts
- Should use the instantiated class instead of class based methods
- Commit the Gemfile.lock
- Get started with some tests

TODO
- [ ] Update blue links
- [ ] Update tests