### PR TITLE
Fix room window not updating on .resize

### DIFF
--- a/lib/windows/room_window.rb
+++ b/lib/windows/room_window.rb
@@ -141,6 +141,13 @@ class RoomWindow < BaseWindow
     @stringprocs = ''
   end
 
+  # Re-render room content after a resize or layout change.
+  #
+  # @return [void]
+  def redraw
+    render
+  end
+
   # Render the complete room display.
   # Clears the window and draws each section (title, description, objects,
   # players, exits, room number, stringprocs) with appropriate presets and


### PR DESCRIPTION
## Summary
- `RoomWindow` was missing a `redraw` method, so `WindowManager#resize` fell through to `Curses::Window#redraw` (`redrawwin`) which only marks the window as damaged without actually re-rendering room content (title, description, objects, exits, etc.)
- Added `RoomWindow#redraw` that delegates to `render`

## Test plan
- [ ] Resize terminal while connected -- room window should repaint correctly
- [ ] Use `.resize` command -- room window should update along with all other windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)