### PR TITLE
Selection overhaul: buffer-anchored selection, live drag highlight, multi-click, unwrapped copy

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1715,7 +1715,10 @@ to the main window as if you had typed it.
 
 **Text selection:** When `.links` is on, you can drag to select text within
 any window. The selection is clamped to the window boundary — dragging in the
-main window won't bleed into adjacent windows. Selected text is copied via
+main window won't bleed into adjacent windows. Selections are anchored to the
+text itself, not the screen position: if new lines arrive between press and
+release, you still copy the text you pressed on, even after it scrolls.
+Selected text is copied via
 OSC 52 (if your terminal supports it) and saved to `/tmp/profanity_selection.txt`.
 Native terminal selection is unavailable while `.links` is on; toggle it off
 if you prefer your terminal's built-in selection.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1405,6 +1405,30 @@ restore text selection. See [Link Display](#13-link-display) for details.
 .links
 ```
 
+### .select
+
+Toggle drag-to-select independently of `.links`. Use this to get
+Profanity's text selection (drag, double-click word, triple-click line)
+without clickable links. Like `.links`, it captures the mouse, so native
+terminal selection is unavailable while it is on. Selection is active
+when either `.links` or `.select` is on.
+
+```
+.select
+```
+
+### .draghl
+
+Toggle the live selection highlight that follows the pointer while
+dragging. Defaults to on; the choice is saved to
+`~/.profanity/settings.json`. Turn it off if your terminal misbehaves
+with mouse motion reporting — the selection still works, with the
+highlight appearing when you release the button.
+
+```
+.draghl
+```
+
 ### .scrollcfg
 
 Launch the interactive mouse scroll wheel calibration wizard. See
@@ -1713,15 +1737,22 @@ text sends the associated command to the game server. In DragonRealms, this
 executes the `cmd` attribute (e.g., `get #40872332`). The command is echoed
 to the main window as if you had typed it.
 
-**Text selection:** When `.links` is on, you can drag to select text within
-any window. The selection is clamped to the window boundary — dragging in the
-main window won't bleed into adjacent windows. Selections are anchored to the
-text itself, not the screen position: if new lines arrive between press and
-release, you still copy the text you pressed on, even after it scrolls.
+**Text selection:** When `.links` (or `.select`) is on, you can drag to
+select text within any window. The selection is clamped to the window
+boundary — dragging in the main window won't bleed into adjacent windows.
+Selections are anchored to the text itself, not the screen position: if new
+lines arrive between press and release, you still copy the text you pressed
+on, even after it scrolls. The highlight follows the pointer live while you
+drag (toggle with `.draghl` if your terminal misbehaves), holding the
+pointer at a window's top or bottom edge auto-scrolls to extend the
+selection, double-click selects the word under the cursor, and triple-click
+selects the whole line. Lines that were word-wrapped for display are copied
+as one logical line, without the mid-sentence breaks. A brief
+`[copied N chars]` note appears in the main window after each copy.
 Selected text is copied via
 OSC 52 (if your terminal supports it) and saved to `/tmp/profanity_selection.txt`.
-Native terminal selection is unavailable while `.links` is on; toggle it off
-if you prefer your terminal's built-in selection.
+Native terminal selection is unavailable while `.links` or `.select` is on;
+toggle both off if you prefer your terminal's built-in selection.
 
 To customize the link color, override the `links` preset in your settings XML:
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1423,7 +1423,9 @@ Toggle the live selection highlight that follows the pointer while
 dragging. Defaults to on; the choice is saved to
 `~/.profanity/settings.json`. Turn it off if your terminal misbehaves
 with mouse motion reporting — the selection still works, with the
-highlight appearing when you release the button.
+highlight appearing when you release the button. (GNU Screen and tmux
+generally don't forward motion events at all; there the highlight
+appears on release regardless of this setting.)
 
 ```
 .draghl
@@ -1751,8 +1753,17 @@ as one logical line, without the mid-sentence breaks. A brief
 `[copied N chars]` note appears in the main window after each copy.
 Selected text is copied via
 OSC 52 (if your terminal supports it) and saved to `/tmp/profanity_selection.txt`.
-Native terminal selection is unavailable while `.links` or `.select` is on;
-toggle both off if you prefer your terminal's built-in selection.
+Native terminal selection is unavailable while `.links` or `.select` is on
+because the terminal hands the mouse to Profanity — but nearly all terminal
+emulators bypass mouse capture when you hold a modifier: **Shift+drag**
+(Option+drag on macOS) still gives you native selection at any time.
+Toggle `.links` and `.select` off if you prefer native selection without
+the modifier.
+
+Inside GNU Screen or tmux, pointer *motion* events may not be forwarded to
+Profanity even though clicks are. Selection still works there — the live
+highlight just appears when you release the button instead of following
+the drag, and edge auto-scroll is unavailable.
 
 To customize the link color, override the `links` preset in your settings XML:
 

--- a/lib/anchored_selection.rb
+++ b/lib/anchored_selection.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+# anchored_selection.rb: Stable line-ID coordinate math for text selection.
+
+# Pure coordinate math for buffer-anchored text selection.
+#
+# Text window buffers are unshift-based (newest line at index 0), so a
+# line's buffer index shifts every time new text arrives. Anchoring a
+# selection to a screen row or buffer index therefore silently drifts
+# onto different text mid-drag. Instead, each window keeps a monotonic
+# count of lines ever appended (+lines_appended+), which gives every
+# buffer line a stable ID:
+#
+#   id    = lines_appended - buffer_index   (1 = oldest, grows with new lines)
+#   index = lines_appended - id
+#
+# IDs never change once assigned, so a selection stored as
+# (start_id, start_x, end_id, end_x) stays glued to the same text no
+# matter how much output arrives or how far the user scrolls.
+#
+# All functions here are pure (no curses, no window state) so the
+# row <-> ID mapping and extraction logic can be unit tested headless.
+module AnchoredSelection
+  module_function
+
+  # Number of buffer lines currently visible in the content area.
+  # Accounts for partially-filled buffers (fewer lines than rows).
+  #
+  # @param buffer_length [Integer] total lines in the buffer
+  # @param buffer_pos [Integer] scroll offset from the bottom (0 = live)
+  # @param height [Integer] content-area height in rows
+  # @return [Integer] visible line count (may be zero or negative when empty)
+  def visible_lines(buffer_length, buffer_pos, height)
+    [buffer_length - buffer_pos, height].min
+  end
+
+  # Stable ID of the buffer line displayed at a content-area row.
+  # Rows outside the populated area are clamped to the nearest line so
+  # drags that wander above/below the text still anchor sensibly.
+  #
+  # @param row [Integer] content-area row (0 = top)
+  # @param lines_appended [Integer] monotonic append counter
+  # @param buffer_pos [Integer] scroll offset from the bottom
+  # @param buffer_length [Integer] total lines in the buffer
+  # @param height [Integer] content-area height in rows
+  # @return [Integer, nil] stable line ID, or nil if the buffer is empty
+  def id_at_row(row, lines_appended:, buffer_pos:, buffer_length:, height:)
+    visible = visible_lines(buffer_length, buffer_pos, height)
+    return nil if visible <= 0
+
+    row = row.clamp(0, visible - 1)
+    index = buffer_pos + (visible - 1 - row)
+    return nil if index.negative? || index >= buffer_length
+
+    lines_appended - index
+  end
+
+  # Content-area row where a stable line ID is currently displayed.
+  #
+  # @param id [Integer] stable line ID
+  # @param lines_appended [Integer] monotonic append counter
+  # @param buffer_pos [Integer] scroll offset from the bottom
+  # @param buffer_length [Integer] total lines in the buffer
+  # @param height [Integer] content-area height in rows
+  # @return [Integer, nil] row (0 = top), or nil if scrolled out of view
+  def row_of_id(id, lines_appended:, buffer_pos:, buffer_length:, height:)
+    visible = visible_lines(buffer_length, buffer_pos, height)
+    return nil if visible <= 0
+
+    index = lines_appended - id
+    return nil if index.negative? || index >= buffer_length
+
+    row = visible - 1 - (index - buffer_pos)
+    return nil if row.negative? || row >= visible
+
+    row
+  end
+
+  # Normalize a selection so the start is the older (topmost) endpoint.
+  # Smaller IDs are older lines, which render above newer ones.
+  #
+  # @param start_id [Integer] anchor line ID
+  # @param start_x [Integer] anchor column
+  # @param end_id [Integer] endpoint line ID
+  # @param end_x [Integer] endpoint column
+  # @return [Array<Integer>] [start_id, start_x, end_id, end_x] ordered oldest-first
+  def normalize(start_id, start_x, end_id, end_x)
+    if start_id > end_id || (start_id == end_id && start_x > end_x)
+      [end_id, end_x, start_id, start_x]
+    else
+      [start_id, start_x, end_id, end_x]
+    end
+  end
+
+  # Extract the selected text from a buffer by stable line IDs.
+  # Lines that have been evicted (past max buffer size) or not yet
+  # appended are skipped; column bounds are clamped to line length.
+  #
+  # @param buffer [Array<Array(String, Array<Hash>)>] line buffer, newest first
+  # @param lines_appended [Integer] monotonic append counter
+  # @param start_id [Integer] anchor line ID
+  # @param start_x [Integer] anchor column
+  # @param end_id [Integer] endpoint line ID
+  # @param end_x [Integer] endpoint column
+  # @return [String] selected text, lines joined by newlines
+  def extract(buffer, lines_appended, start_id, start_x, end_id, end_x)
+    start_id, start_x, end_id, end_x = normalize(start_id, start_x, end_id, end_x)
+
+    lines = []
+    (start_id..end_id).each do |id|
+      index = lines_appended - id
+      next if index.negative? || index >= buffer.length
+
+      text = buffer[index][0] || ''
+      from = id == start_id ? start_x : 0
+      to = id == end_id ? end_x : text.length
+      from = from.clamp(0, text.length)
+      to = to.clamp(from, text.length)
+      lines << text[from...to]
+    end
+    lines.join("\n")
+  end
+end

--- a/lib/anchored_selection.rb
+++ b/lib/anchored_selection.rb
@@ -96,28 +96,103 @@ module AnchoredSelection
   # Lines that have been evicted (past max buffer size) or not yet
   # appended are skipped; column bounds are clamped to line length.
   #
-  # @param buffer [Array<Array(String, Array<Hash>)>] line buffer, newest first
+  # Buffer entries may carry a wrap-continuation flag at index 2 (set by
+  # BaseWindow#wrap_text). Consecutive selected display lines that belong
+  # to one logical line are rejoined without the hard wrap: the previous
+  # piece keeps its break whitespace (StyledText#wrap leaves it there) and
+  # the continuation's artificial indent is stripped, so copied text has
+  # no mid-sentence line breaks.
+  #
+  # @param buffer [Array<Array(String, Array<Hash>, Boolean)>] line buffer, newest first
   # @param lines_appended [Integer] monotonic append counter
   # @param start_id [Integer] anchor line ID
   # @param start_x [Integer] anchor column
   # @param end_id [Integer] endpoint line ID
   # @param end_x [Integer] endpoint column
-  # @return [String] selected text, lines joined by newlines
+  # @return [String] selected text, logical lines joined by newlines
   def extract(buffer, lines_appended, start_id, start_x, end_id, end_x)
     start_id, start_x, end_id, end_x = normalize(start_id, start_x, end_id, end_x)
 
     lines = []
+    prev_id = nil
     (start_id..end_id).each do |id|
       index = lines_appended - id
       next if index.negative? || index >= buffer.length
 
-      text = buffer[index][0] || ''
+      entry = buffer[index]
+      text = entry[0] || ''
       from = id == start_id ? start_x : 0
       to = id == end_id ? end_x : text.length
       from = from.clamp(0, text.length)
       to = to.clamp(from, text.length)
-      lines << text[from...to]
+      piece = text[from...to]
+
+      if entry[2] && prev_id == id - 1 && !lines.empty?
+        lines[-1] += piece.lstrip
+      else
+        lines << piece
+      end
+      prev_id = id
     end
     lines.join("\n")
+  end
+
+  # Text of the buffer line with the given stable ID.
+  #
+  # @param buffer [Array<Array(String, Array<Hash>)>] line buffer, newest first
+  # @param lines_appended [Integer] monotonic append counter
+  # @param id [Integer] stable line ID
+  # @return [String, nil] line text, or nil if evicted / never appended
+  def line_at(buffer, lines_appended, id)
+    index = lines_appended - id
+    return nil if index.negative? || index >= buffer.length
+
+    buffer[index][0]
+  end
+
+  # Span of the whitespace-delimited word at column x, for double-click
+  # word selection.
+  #
+  # @param text [String] the line text
+  # @param x [Integer] column within the line
+  # @return [Array<Integer>, nil] [from, to) span, or nil if the line is
+  #   empty or the column is on whitespace
+  def word_span(text, x)
+    return nil if text.nil? || text.empty?
+
+    x = x.clamp(0, text.length - 1)
+    return nil if text[x].match?(/\s/)
+
+    from = x
+    from -= 1 while from.positive? && !text[from - 1].match?(/\s/)
+    to = x + 1
+    to += 1 while to < text.length && !text[to].match?(/\s/)
+    [from, to]
+  end
+
+  # IDs of the first and last display lines of the logical (unwrapped)
+  # line containing the given ID, for triple-click line selection.
+  # Walks continuation flags backward to the wrap start and forward to
+  # the last continuation, stopping at evicted/missing lines.
+  #
+  # @param buffer [Array<Array(String, Array<Hash>, Boolean)>] line buffer, newest first
+  # @param lines_appended [Integer] monotonic append counter
+  # @param id [Integer] stable line ID anywhere within the logical line
+  # @return [Array<Integer>] [first_id, last_id]
+  def logical_line_span(buffer, lines_appended, id)
+    continuation = lambda do |line_id|
+      index = lines_appended - line_id
+      index >= 0 && index < buffer.length && buffer[index][2]
+    end
+    present = lambda do |line_id|
+      index = lines_appended - line_id
+      index >= 0 && index < buffer.length
+    end
+
+    first = id
+    first -= 1 while continuation.call(first) && present.call(first - 1)
+    last = id
+    last += 1 while continuation.call(last + 1)
+    [first, last]
   end
 end

--- a/lib/application.rb
+++ b/lib/application.rb
@@ -287,7 +287,7 @@ class Application
     end
     if (window = @window_mgr.stream[MAIN_STREAM])
       msg = if @shared_state.blue_links
-              '* Links: ON (clickable links + drag-to-select)'
+              '* Links: ON (clickable links + drag-to-select; Shift+drag for native selection)'
             elsif @selection_enabled
               '* Links: OFF (drag-to-select still on via .select)'
             else
@@ -306,7 +306,7 @@ class Application
       @mouse_scroll.disable_click_events
     end
     msg = if @selection_enabled
-            '* Select: ON (drag-to-select without clickable links)'
+            '* Select: ON (drag-to-select; Shift+drag for native selection)'
           elsif @shared_state.blue_links
             '* Select: OFF (drag-to-select still on via .links)'
           else

--- a/lib/application.rb
+++ b/lib/application.rb
@@ -34,6 +34,8 @@ class Application
     '.tab <N|name>      Switch tab by number or name',
     '.arrow             Cycle arrow keys: history/page/line',
     '.links             Toggle in-game link highlighting',
+    '.select            Toggle drag-to-select without links',
+    '.draghl            Toggle live highlight while dragging',
     '.scrollcfg         Configure mouse scroll wheel',
     '.highlight <text>   Add cyan highlight for text (session only)',
     '.unhighlight <text> Remove an inline highlight',
@@ -70,6 +72,7 @@ class Application
     @window_mgr = WindowManager.new
     @key_binding = {}
     @key_action = {}
+    @selection_enabled = false
 
     setup_key_actions
 
@@ -124,6 +127,10 @@ class Application
       handle_dot_arrow
     elsif cmd =~ /^\.links/i
       handle_dot_links
+    elsif cmd =~ /^\.select/i
+      handle_dot_select
+    elsif cmd =~ /^\.draghl/i
+      handle_dot_draghl
     elsif cmd =~ /^\.scrollcfg/i
       @mouse_scroll.start_configuration
     elsif (match = cmd.match(/^\.unhighlight\s+(?<pattern>.+)/i))
@@ -270,7 +277,8 @@ class Application
     @shared_state.blue_links = !@shared_state.blue_links
     if @shared_state.blue_links
       @mouse_scroll.enable_click_events
-    else
+    elsif !@selection_enabled
+      # Keep mouse capture when .select is still on
       @mouse_scroll.disable_click_events
     end
     if (room_win = @window_mgr.room['room'])
@@ -280,12 +288,41 @@ class Application
     if (window = @window_mgr.stream[MAIN_STREAM])
       msg = if @shared_state.blue_links
               '* Links: ON (clickable links + drag-to-select)'
+            elsif @selection_enabled
+              '* Links: OFF (drag-to-select still on via .select)'
             else
               '* Links: OFF (native terminal selection)'
             end
       window.add_string(msg, feedback_colors(msg))
       CursesRenderer.doupdate
     end
+  end
+
+  def handle_dot_select
+    @selection_enabled = !@selection_enabled
+    if @selection_enabled || @shared_state.blue_links
+      @mouse_scroll.enable_click_events
+    else
+      @mouse_scroll.disable_click_events
+    end
+    msg = if @selection_enabled
+            '* Select: ON (drag-to-select without clickable links)'
+          elsif @shared_state.blue_links
+            '* Select: OFF (drag-to-select still on via .links)'
+          else
+            '* Select: OFF (native terminal selection)'
+          end
+    write_to_client(msg)
+  end
+
+  def handle_dot_draghl
+    @mouse_scroll.drag_highlight = !@mouse_scroll.drag_highlight
+    msg = if @mouse_scroll.drag_highlight
+            '* Drag highlight: ON (highlight follows the pointer while dragging)'
+          else
+            '* Drag highlight: OFF (highlight appears when you release)'
+          end
+    write_to_client(msg)
   end
 
   def handle_dot_highlight(pattern)
@@ -577,10 +614,12 @@ class Application
       CursesRenderer.synchronize do
         # Tick countdowns on every iteration (~100ms), regardless of input
         countdown_updated = tick_countdowns
+        # Drag held at a window edge keeps scrolling once per tick
+        drag_scrolled = tick_drag_auto_scroll
 
         ch = @cmd_buffer.window.getch
         if ch.nil?
-          Curses.doupdate if countdown_updated
+          Curses.doupdate if countdown_updated || drag_scrolled
           next
         end
 
@@ -637,13 +676,7 @@ class Application
     bstate = mouse.bstate
 
     if (bstate & Curses::BUTTON1_PRESSED) != 0
-      SelectionManager.clear_selection
-      window = BaseWindow.find_window_at(screen_y, screen_x)
-      if window
-        rel_y = screen_y - window.begy
-        rel_x = screen_x - window.begx
-        SelectionManager.start_selection(window, rel_y, rel_x)
-      end
+      handle_mouse_press(screen_y, screen_x)
     elsif (bstate & Curses::BUTTON1_RELEASED) != 0
       handle_mouse_release(screen_y, screen_x)
     elsif defined?(Curses::BUTTON1_CLICKED) && (bstate & Curses::BUTTON1_CLICKED) != 0
@@ -654,10 +687,40 @@ class Application
         rel_x = screen_x - window.begx
         dispatch_link(window, rel_y, rel_x)
       end
+    elsif MouseScroll::MOTION_EVENTS.nonzero? && (bstate & MouseScroll::MOTION_EVENTS) != 0
+      handle_mouse_drag(screen_y, screen_x)
     end
   end
 
+  def handle_mouse_press(screen_y, screen_x)
+    window = BaseWindow.find_window_at(screen_y, screen_x)
+    unless window
+      SelectionManager.clear_selection
+      return
+    end
+
+    rel_y = screen_y - window.begy
+    rel_x = screen_x - window.begx
+    multi_click = SelectionManager.start_selection(window, rel_y, rel_x)
+    # Motion reporting only while the button is held — a permanent
+    # motion stream corrupts the display
+    @mouse_scroll.begin_drag_capture
+    CursesRenderer.doupdate if multi_click
+  end
+
+  # Live highlight update from a motion report while button 1 is held.
+  # SelectionManager throttles redraws so a motion flood coalesces.
+  def handle_mouse_drag(screen_y, screen_x)
+    window = SelectionManager.active_window
+    return unless window && SelectionManager.selecting
+
+    rel_y = screen_y - window.begy
+    rel_x = screen_x - window.begx
+    CursesRenderer.doupdate if SelectionManager.drag_update(rel_y, rel_x)
+  end
+
   def handle_mouse_release(screen_y, screen_x)
+    @mouse_scroll.end_drag_capture
     return unless SelectionManager.selecting
 
     window = SelectionManager.active_window
@@ -671,18 +734,49 @@ class Application
     start_pos = SelectionManager.start_pos
 
     if start_pos && start_pos[0] == rel_y && (start_pos[1] - rel_x).abs <= 3
-      # Single click (no drag): check for link, skip selection
-      dispatch_link(window, rel_y, rel_x)
-      SelectionManager.clear_selection
+      if SelectionManager.multi_click_selected?
+        # Double/triple click: copy the expanded word/line selection
+        finalize_selection
+      else
+        # Single click (no drag): check for link, skip selection
+        dispatch_link(window, rel_y, rel_x)
+        SelectionManager.clear_selection
+      end
     else
       # Actual drag: finalize selection and copy to clipboard
       SelectionManager.update_selection(rel_y, rel_x)
-      SelectionManager.end_selection
-      CursesRenderer.doupdate
+      finalize_selection
     end
   end
 
+  # Copy the finished selection and show brief feedback in the main window.
+  def finalize_selection
+    chars = SelectionManager.end_selection
+    write_to_client("* [copied #{chars} chars]") if chars&.positive?
+    CursesRenderer.doupdate
+  end
+
+  # While a drag is held at a window's top or bottom edge, keep scrolling
+  # one line per input-loop tick (~100ms) and extend the selection.
+  # Motion events stop when the pointer stops moving, so the tick drives
+  # the repeat. Returns true if the screen needs a refresh.
+  def tick_drag_auto_scroll
+    return false unless SelectionManager.selecting
+
+    window = SelectionManager.active_window
+    pos = SelectionManager.last_drag_pos
+    return false unless window && pos
+
+    scrolled = window.drag_auto_scroll(pos[0])
+    SelectionManager.update_selection(pos[0], pos[1]) if scrolled
+    scrolled
+  end
+
   def dispatch_link(window, rel_y, rel_x)
+    # Links may be toggled off while selection capture (.select) stays on;
+    # lines rendered earlier can still carry cmd runs that must not fire
+    return unless @shared_state.blue_links
+
     if (link_cmd = window.link_cmd_at(rel_y, rel_x))
       if (main = @window_mgr.stream[MAIN_STREAM])
         @window_mgr.add_prompt(main, @shared_state.prompt_text, link_cmd)

--- a/lib/mouse_scroll.rb
+++ b/lib/mouse_scroll.rb
@@ -33,6 +33,12 @@ class MouseScroll
   # highlight-on-release).
   MOTION_EVENTS = defined?(Curses::REPORT_MOUSE_POSITION) ? Curses::REPORT_MOUSE_POSITION : 0
 
+  # ncurses default click-resolution interval, in milliseconds. The curses
+  # gem's mouseinterval returns a boolean (whether the interval was set),
+  # not the previous interval, so the prior value cannot be read back;
+  # restore this documented default when re-enabling click resolution.
+  DEFAULT_MOUSEINTERVAL = 166
+
   # @return [Boolean] whether the live drag highlight is enabled.
   #   When false, selection falls back to highlight-on-release and no
   #   motion events are ever requested from the terminal.
@@ -51,7 +57,7 @@ class MouseScroll
 
     @click_events_enabled = false
     @drag_highlight = ProfanitySettings.load_setting('DRAG_HIGHLIGHT', true)
-    @saved_mouseinterval = nil
+    @click_resolution_suppressed = false
     load_settings
   end
 
@@ -190,25 +196,26 @@ class MouseScroll
   end
 
   # Stop ncurses from buffering press/release pairs to synthesize
-  # click events; remembers the previous interval for restoration.
+  # click events (mouseinterval 0) and record that we did so.
   #
   # @return [void]
   def suppress_click_resolution
     return unless Curses.respond_to?(:mouseinterval)
 
-    previous = Curses.mouseinterval(0)
-    @saved_mouseinterval ||= previous
+    Curses.mouseinterval(0)
+    @click_resolution_suppressed = true
   end
 
-  # Restore the click-resolution interval saved by
-  # {#suppress_click_resolution}, if any.
+  # Re-enable click-resolution buffering after {#suppress_click_resolution}
+  # by restoring the ncurses default interval. No-op unless suppression is
+  # currently active.
   #
   # @return [void]
   def restore_click_resolution
-    return unless @saved_mouseinterval && Curses.respond_to?(:mouseinterval)
+    return unless @click_resolution_suppressed && Curses.respond_to?(:mouseinterval)
 
-    Curses.mouseinterval(@saved_mouseinterval)
-    @saved_mouseinterval = nil
+    Curses.mouseinterval(DEFAULT_MOUSEINTERVAL)
+    @click_resolution_suppressed = false
   end
 
   # Load saved scroll button masks from settings and enable the mouse listener.

--- a/lib/mouse_scroll.rb
+++ b/lib/mouse_scroll.rb
@@ -22,10 +22,21 @@ class MouseScroll
 
   # Bitmask for mouse events when .links is active.
   # BUTTON1 press/release/click for link detection and drag-to-select.
-  # Does NOT include REPORT_MOUSE_POSITION (causes display corruption).
-  # Drag highlight appears on release instead of during drag.
+  # Does NOT include REPORT_MOUSE_POSITION in the steady state — a
+  # constant motion-event stream corrupts the display. Motion reporting
+  # is added only while button 1 is held (see {#begin_drag_capture}).
   CLICK_EVENTS = Curses::BUTTON1_PRESSED | Curses::BUTTON1_RELEASED |
                  (defined?(Curses::BUTTON1_CLICKED) ? Curses::BUTTON1_CLICKED : 0)
+
+  # Bitmask for pointer motion reports, used for live drag highlight.
+  # Zero when the curses build doesn't expose it (feature degrades to
+  # highlight-on-release).
+  MOTION_EVENTS = defined?(Curses::REPORT_MOUSE_POSITION) ? Curses::REPORT_MOUSE_POSITION : 0
+
+  # @return [Boolean] whether the live drag highlight is enabled.
+  #   When false, selection falls back to highlight-on-release and no
+  #   motion events are ever requested from the terminal.
+  attr_reader :drag_highlight
 
   # @param key_action [Hash<String, Proc>] the key action registry
   # @param display_fn [Proc] callback to display messages: display_fn.call(text)
@@ -39,6 +50,8 @@ class MouseScroll
     @bstate_counts = {}
 
     @click_events_enabled = false
+    @drag_highlight = ProfanitySettings.load_setting('DRAG_HIGHLIGHT', true)
+    @saved_mouseinterval = nil
     load_settings
   end
 
@@ -93,33 +106,80 @@ class MouseScroll
     @config_state != :idle
   end
 
-  # Enable mouse click events for clickable links.
-  # Called when .links is toggled on.
+  # Enable mouse click events for clickable links and drag-to-select.
+  # Called when .links or .select is toggled on.
+  #
+  # With drag highlight on, click resolution is also disabled
+  # (mouseinterval 0) so presses and releases arrive raw — the
+  # application's own click-vs-drag heuristic takes over, and no events
+  # are buffered waiting to synthesize BUTTON1_CLICKED.
   #
   # @return [void]
   def enable_click_events
     @click_events_enabled = true
+    suppress_click_resolution if @drag_highlight
     apply_mouse_mask
   end
 
   # Disable mouse click events, restoring native terminal selection.
-  # Called when .links is toggled off.
+  # Called when .links / .select are toggled off.
   #
   # @return [void]
   def disable_click_events
     @click_events_enabled = false
+    restore_click_resolution
     apply_mouse_mask
   end
 
+  # Toggle the live drag highlight. Adjusts click resolution to match
+  # if mouse capture is currently active, and persists the choice.
+  #
+  # @param value [Boolean] true to highlight while dragging
+  # @return [void]
+  def drag_highlight=(value)
+    @drag_highlight = value
+    if @click_events_enabled
+      value ? suppress_click_resolution : restore_click_resolution
+    end
+    ProfanitySettings.save_setting('DRAG_HIGHLIGHT', value)
+  end
+
+  # Add pointer-motion reporting to the mouse mask for the duration of
+  # a button-1 drag. Called on press; {#end_drag_capture} restores the
+  # steady-state mask on release. Keeping motion reporting scoped to
+  # the drag avoids the constant event stream that corrupts the display.
+  #
+  # @return [void]
+  def begin_drag_capture
+    return unless @click_events_enabled && @drag_highlight && MOTION_EVENTS.nonzero?
+
+    Curses.mousemask(base_mask | MOTION_EVENTS)
+  end
+
+  # Restore the steady-state mouse mask after a drag ends.
+  #
+  # @return [void]
+  def end_drag_capture
+    apply_mouse_mask if @click_events_enabled
+  end
+
   private
+
+  # Compute the steady-state mouse mask from scroll and click event bits.
+  #
+  # @return [Integer]
+  def base_mask
+    mask = 0
+    mask |= @button4_mask | @button5_mask if @button4_mask && @button5_mask
+    mask |= CLICK_EVENTS if @click_events_enabled
+    mask
+  end
 
   # Apply the current mouse mask combining scroll and click event bits.
   #
   # @return [void]
   def apply_mouse_mask
-    mask = 0
-    mask |= @button4_mask | @button5_mask if @button4_mask && @button5_mask
-    mask |= CLICK_EVENTS if @click_events_enabled
+    mask = base_mask
     if mask.nonzero?
       Curses.mousemask(mask)
       @listener_enabled = true
@@ -127,6 +187,28 @@ class MouseScroll
       Curses.mousemask(0)
       @listener_enabled = false
     end
+  end
+
+  # Stop ncurses from buffering press/release pairs to synthesize
+  # click events; remembers the previous interval for restoration.
+  #
+  # @return [void]
+  def suppress_click_resolution
+    return unless Curses.respond_to?(:mouseinterval)
+
+    previous = Curses.mouseinterval(0)
+    @saved_mouseinterval ||= previous
+  end
+
+  # Restore the click-resolution interval saved by
+  # {#suppress_click_resolution}, if any.
+  #
+  # @return [void]
+  def restore_click_resolution
+    return unless @saved_mouseinterval && Curses.respond_to?(:mouseinterval)
+
+    Curses.mouseinterval(@saved_mouseinterval)
+    @saved_mouseinterval = nil
   end
 
   # Load saved scroll button masks from settings and enable the mouse listener.

--- a/lib/profanity_settings.rb
+++ b/lib/profanity_settings.rb
@@ -150,15 +150,39 @@ module ProfanitySettings
     nil
   end
 
-  # Save mouse scroll settings to settings.json.
+  # Save mouse scroll settings to settings.json, preserving any other
+  # keys already stored there.
   #
   # @param button4_mask [Integer] scroll-up button mask
   # @param button5_mask [Integer] scroll-down button mask
   # @return [void]
   def self.save_mouse_settings(button4_mask, button5_mask)
-    write(file('settings.json'), JSON.pretty_generate({
-      'BUTTON4_PRESSED_MASK' => button4_mask,
-      'BUTTON5_PRESSED_MASK' => button5_mask
-    }))
+    settings = load_mouse_settings || {}
+    settings['BUTTON4_PRESSED_MASK'] = button4_mask
+    settings['BUTTON5_PRESSED_MASK'] = button5_mask
+    write(file('settings.json'), JSON.pretty_generate(settings))
+  end
+
+  # Read a single value from settings.json.
+  #
+  # @param key [String] setting name
+  # @param default [Object] value returned when the file or key is absent
+  # @return [Object] the stored value or the default
+  def self.load_setting(key, default)
+    settings = load_mouse_settings
+    return default unless settings&.key?(key)
+
+    settings[key]
+  end
+
+  # Write a single value to settings.json, preserving other keys.
+  #
+  # @param key [String] setting name
+  # @param value [Object] JSON-serializable value
+  # @return [void]
+  def self.save_setting(key, value)
+    settings = load_mouse_settings || {}
+    settings[key] = value
+    write(file('settings.json'), JSON.pretty_generate(settings))
   end
 end

--- a/lib/selection_manager.rb
+++ b/lib/selection_manager.rb
@@ -18,6 +18,14 @@
 # Selected text is copied to the system clipboard (pbcopy/xclip/wl-copy),
 # OSC 52 (for remote/SSH sessions), and /tmp/profanity_selection.txt.
 module SelectionManager
+  # Minimum seconds between highlight redraws during a live drag.
+  # Motion events can flood; redrawing every one of them is what caused
+  # display corruption in earlier drag-highlight attempts.
+  DRAG_REDRAW_INTERVAL = 0.05
+
+  # Maximum seconds between presses for double/triple-click detection.
+  MULTI_CLICK_INTERVAL = 0.4
+
   @active_window = nil
   @press_y = nil
   @press_x = nil
@@ -26,9 +34,18 @@ module SelectionManager
   @end_id = nil
   @end_x = nil
   @selecting = false
+  @last_drag_pos = nil
+  @last_drag_redraw = nil
+  @click_count = 0
+  @last_press_time = nil
+  @last_press_window = nil
+  @last_press_y = nil
+  @last_press_x = nil
+  @multi_click_selected = false
 
   class << self
-    attr_reader :active_window, :start_id, :start_x, :end_id, :end_x, :selecting
+    attr_reader :active_window, :start_id, :start_x, :end_id, :end_x, :selecting,
+                :last_drag_pos, :click_count
 
     # Return the window-relative [y, x] press coordinates, or nil if no
     # selection. Used by the input loop's click-vs-drag heuristic, which
@@ -39,16 +56,32 @@ module SelectionManager
       @press_y && @press_x ? [@press_y, @press_x] : nil
     end
 
+    # Whether the current press expanded to a word/line selection via
+    # double/triple-click. The release handler copies this selection
+    # instead of dispatching a link click.
+    #
+    # @return [Boolean]
+    def multi_click_selected?
+      @multi_click_selected
+    end
+
     # Begin a new text selection at the given window coordinates.
     # Clears any previous selection highlight first, then resolves the
     # press position to a stable [line_id, x] anchor immediately — before
     # any incoming text can shift the buffer under it.
     #
+    # Rapid repeat presses at the same spot count as double/triple clicks
+    # and expand the selection to the word / logical line under the cursor.
+    #
     # @param window [BaseWindow] the window where selection starts
     # @param y [Integer] starting row (window-relative)
     # @param x [Integer] starting column (window-relative)
-    # @return [void]
-    def start_selection(window, y, x)
+    # @param now [Float, nil] monotonic clock override for tests
+    # @return [Boolean] true if a multi-click expanded the highlight
+    #   (the caller should refresh the screen)
+    def start_selection(window, y, x, now: nil)
+      now ||= monotonic_now
+      count_click(window, y, x, now)
       clear_selection
       @active_window = window
       @press_y = y
@@ -58,6 +91,7 @@ module SelectionManager
         @end_id, @end_x = anchor
       end
       @selecting = true
+      @multi_click_selected = expand_multi_click
     end
 
     # Extend the current selection to a new endpoint and redraw highlights.
@@ -77,10 +111,32 @@ module SelectionManager
       @active_window.highlight_selection(@start_id, @start_x, @end_id, @end_x)
     end
 
+    # Live-drag update from a mouse motion event, throttled so a flood
+    # of motion reports coalesces into at most one redraw per
+    # {DRAG_REDRAW_INTERVAL}. The drag position is always recorded (for
+    # edge auto-scroll) even when the redraw is skipped.
+    #
+    # @param y [Integer] pointer row (window-relative)
+    # @param x [Integer] pointer column (window-relative)
+    # @param now [Float, nil] monotonic clock override for tests
+    # @return [Boolean] true if the highlight was redrawn
+    def drag_update(y, x, now: nil)
+      return false unless @selecting && @active_window && @start_id
+
+      @last_drag_pos = [y, x]
+      now ||= monotonic_now
+      return false if @last_drag_redraw && (now - @last_drag_redraw) < DRAG_REDRAW_INTERVAL
+
+      @last_drag_redraw = now
+      update_selection(y, x)
+      true
+    end
+
     # Finalize the selection and copy text to the clipboard.
     # The highlight is kept visible until the next selection or click.
     #
-    # @return [void]
+    # @return [Integer, nil] number of characters copied, or nil if
+    #   nothing was extracted
     def end_selection
       return unless @selecting && @active_window
 
@@ -90,13 +146,17 @@ module SelectionManager
       text = @active_window.extract_selection(@start_id, @start_x, @end_id, @end_x)
       if text && !text.empty?
         copy_to_clipboard(text)
+        text.length
       else
         ProfanityLog.write('SelectionManager', "No text extracted: start=(#{@start_id},#{@start_x}) end=(#{@end_id},#{@end_x})")
+        nil
       end
       # Keep highlight visible — cleared on next start_selection or clear_selection
     end
 
     # Reset all selection state and clear any active highlight.
+    # Multi-click timing memory survives so a double-click's second press
+    # (which begins with this reset) still counts.
     #
     # @return [void]
     def clear_selection
@@ -105,7 +165,68 @@ module SelectionManager
       @press_y = @press_x = nil
       @start_id = @start_x = @end_id = @end_x = nil
       @selecting = false
+      @last_drag_pos = nil
+      @last_drag_redraw = nil
+      @multi_click_selected = false
     end
+
+    private
+
+    # @return [Float] monotonic clock reading in seconds
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    # Track rapid repeat presses at the same spot for double/triple-click.
+    # Called before the previous press state is cleared.
+    #
+    # @param window [BaseWindow] the pressed window
+    # @param y [Integer] press row (window-relative)
+    # @param x [Integer] press column (window-relative)
+    # @param now [Float] monotonic clock reading
+    # @return [void]
+    def count_click(window, y, x, now)
+      repeat = @last_press_time &&
+               (now - @last_press_time) <= MULTI_CLICK_INTERVAL &&
+               @last_press_window.equal?(window) &&
+               @last_press_y == y && @last_press_x && (@last_press_x - x).abs <= 1
+      @click_count = repeat ? (@click_count % 3) + 1 : 1
+      @last_press_time = now
+      @last_press_window = window
+      @last_press_y = y
+      @last_press_x = x
+    end
+
+    # Expand the just-anchored selection to the word (double-click) or
+    # logical line (triple-click) under the cursor, and highlight it.
+    #
+    # @return [Boolean] true if the selection was expanded
+    def expand_multi_click
+      return false unless @click_count >= 2 && @start_id && @active_window.respond_to?(:buffer_content)
+
+      buffer = @active_window.buffer_content
+      appended = @active_window.lines_appended
+
+      if @click_count == 2
+        text = AnchoredSelection.line_at(buffer, appended, @start_id)
+        span = text && AnchoredSelection.word_span(text, @start_x)
+        return false unless span
+
+        @start_x, @end_x = span
+      else
+        first, last = AnchoredSelection.logical_line_span(buffer, appended, @start_id)
+        last_text = AnchoredSelection.line_at(buffer, appended, last) || ''
+        @start_id = first
+        @start_x = 0
+        @end_id = last
+        @end_x = last_text.length
+      end
+
+      @active_window.highlight_selection(@start_id, @start_x, @end_id, @end_x)
+      true
+    end
+
+    public
 
     # Copy text to the system clipboard, OSC 52, and a temp file.
     #

--- a/lib/selection_manager.rb
+++ b/lib/selection_manager.rb
@@ -7,30 +7,42 @@
 # Selection is per-window: drag coordinates are clamped to the
 # active window's bounds so selections never bleed across windows.
 #
+# Endpoints are anchored to stable buffer line IDs (see
+# {AnchoredSelection}) at press time, so the selection stays glued to
+# the same text even when new lines arrive or the user scrolls between
+# press and release. The raw press coordinates are kept separately for
+# the click-vs-drag heuristic in the input loop.
+#
 # The highlight persists after release so the user can see what was
 # selected. It is cleared on the next mouse press or link click.
 # Selected text is copied to the system clipboard (pbcopy/xclip/wl-copy),
 # OSC 52 (for remote/SSH sessions), and /tmp/profanity_selection.txt.
 module SelectionManager
   @active_window = nil
-  @start_y = nil
+  @press_y = nil
+  @press_x = nil
+  @start_id = nil
   @start_x = nil
-  @end_y = nil
+  @end_id = nil
   @end_x = nil
   @selecting = false
 
   class << self
-    attr_reader :active_window, :start_y, :start_x, :end_y, :end_x, :selecting
+    attr_reader :active_window, :start_id, :start_x, :end_id, :end_x, :selecting
 
-    # Return the starting [y, x] coordinates as a pair, or nil if no selection.
+    # Return the window-relative [y, x] press coordinates, or nil if no
+    # selection. Used by the input loop's click-vs-drag heuristic, which
+    # compares screen positions — not buffer anchors.
     #
     # @return [Array<Integer>, nil] [y, x] pair or nil
     def start_pos
-      @start_y && @start_x ? [@start_y, @start_x] : nil
+      @press_y && @press_x ? [@press_y, @press_x] : nil
     end
 
     # Begin a new text selection at the given window coordinates.
-    # Clears any previous selection highlight first.
+    # Clears any previous selection highlight first, then resolves the
+    # press position to a stable [line_id, x] anchor immediately — before
+    # any incoming text can shift the buffer under it.
     #
     # @param window [BaseWindow] the window where selection starts
     # @param y [Integer] starting row (window-relative)
@@ -39,24 +51,30 @@ module SelectionManager
     def start_selection(window, y, x)
       clear_selection
       @active_window = window
-      @start_y = y
-      @start_x = x
-      @end_y = y
-      @end_x = x
+      @press_y = y
+      @press_x = x
+      if (anchor = window.selection_anchor_at(y, x))
+        @start_id, @start_x = anchor
+        @end_id, @end_x = anchor
+      end
       @selecting = true
     end
 
     # Extend the current selection to a new endpoint and redraw highlights.
+    # The endpoint is resolved against the window's current scroll/buffer
+    # state, so dragging works even after the content has moved.
     #
     # @param y [Integer] new end row (window-relative)
     # @param x [Integer] new end column (window-relative)
     # @return [void]
     def update_selection(y, x)
-      return unless @selecting && @active_window
+      return unless @selecting && @active_window && @start_id
 
-      @end_y = y
-      @end_x = x
-      @active_window.highlight_selection(@start_y, @start_x, @end_y, @end_x)
+      anchor = @active_window.selection_anchor_at(y, x)
+      return unless anchor
+
+      @end_id, @end_x = anchor
+      @active_window.highlight_selection(@start_id, @start_x, @end_id, @end_x)
     end
 
     # Finalize the selection and copy text to the clipboard.
@@ -67,11 +85,13 @@ module SelectionManager
       return unless @selecting && @active_window
 
       @selecting = false
-      text = @active_window.extract_selection(@start_y, @start_x, @end_y, @end_x)
+      return unless @start_id && @end_id
+
+      text = @active_window.extract_selection(@start_id, @start_x, @end_id, @end_x)
       if text && !text.empty?
         copy_to_clipboard(text)
       else
-        ProfanityLog.write('SelectionManager', "No text extracted: start=(#{@start_y},#{@start_x}) end=(#{@end_y},#{@end_x})")
+        ProfanityLog.write('SelectionManager', "No text extracted: start=(#{@start_id},#{@start_x}) end=(#{@end_id},#{@end_x})")
       end
       # Keep highlight visible — cleared on next start_selection or clear_selection
     end
@@ -82,7 +102,8 @@ module SelectionManager
     def clear_selection
       @active_window&.clear_highlight
       @active_window = nil
-      @start_y = @start_x = @end_y = @end_x = nil
+      @press_y = @press_x = nil
+      @start_id = @start_x = @end_id = @end_x = nil
       @selecting = false
     end
 

--- a/lib/windows/base_window.rb
+++ b/lib/windows/base_window.rb
@@ -82,14 +82,16 @@ class BaseWindow < Curses::Window
   # @param width [Integer] maximum line width in characters
   # @param string_colors [Array<Hash>] color region descriptors for the full string
   # @param indent [Boolean] whether continuation lines should be indented
-  # @yield [line, line_colors] each wrapped line and its adjusted color regions
+  # @yield [line, line_colors, continuation] each wrapped line, its adjusted
+  #   color regions, and whether it continues the previous wrapped line
   # @yieldparam line [String] one wrapped line of text
   # @yieldparam line_colors [Array<Hash>] color regions scoped to this line
+  # @yieldparam continuation [Boolean] true for the 2nd+ line of a wrapped string
   # @return [void]
   def wrap_text(string, width, string_colors, indent: true)
     styled = StyledText.new(string, string_colors)
-    styled.wrap(width, indent: indent).each do |wrapped_line|
-      yield wrapped_line.text, wrapped_line.runs
+    styled.wrap(width, indent: indent).each_with_index do |wrapped_line, idx|
+      yield wrapped_line.text, wrapped_line.runs, idx.positive?
     end
   end
 
@@ -244,6 +246,24 @@ class BaseWindow < Curses::Window
   # @return [Array<Integer>, nil] [line_id, x] anchor, or nil
   def selection_anchor_at(_rel_y, _rel_x)
     nil
+  end
+
+  # Monotonic count of lines ever appended, for selection anchoring.
+  # Overridden by windows with line buffers.
+  #
+  # @return [Integer]
+  def lines_appended
+    0
+  end
+
+  # Scroll one line when a drag pointer sits at this window's top or
+  # bottom edge. Subclasses with scrollable buffers override this.
+  # The default is a no-op for window types that don't scroll.
+  #
+  # @param _rel_y [Integer] drag row relative to window top
+  # @return [Boolean] true if the view actually scrolled
+  def drag_auto_scroll(_rel_y)
+    false
   end
 
   # Whether text is currently selected in this window.

--- a/lib/windows/base_window.rb
+++ b/lib/windows/base_window.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../styled_text'
+require_relative '../anchored_selection'
 
 # Base class for all ProfanityFE window types.
 # Provides shared rendering, word-wrap, scrollbar, selection, and window registry.
@@ -225,11 +226,25 @@ class BaseWindow < Curses::Window
     buffer_content.length
   end
 
-  # @return [Array<Integer>, nil] [y, x] coordinates where the selection begins
+  # @return [Array<Integer>, nil] [line_id, x] where the selection begins
+  #   (line_id is a stable buffer line ID — see {AnchoredSelection})
   attr_accessor :selection_start
 
-  # @return [Array<Integer>, nil] [y, x] coordinates where the selection ends
+  # @return [Array<Integer>, nil] [line_id, x] where the selection ends
   attr_accessor :selection_end
+
+  # Resolve window-relative coordinates to a stable selection anchor.
+  # Subclasses with line buffers (TextWindow, TabbedTextWindow) override
+  # this to return a [line_id, x] pair that stays glued to the same text
+  # as the buffer grows or scrolls. The default returns nil for window
+  # types that don't support selection.
+  #
+  # @param _rel_y [Integer] row relative to window top
+  # @param _rel_x [Integer] column relative to window left
+  # @return [Array<Integer>, nil] [line_id, x] anchor, or nil
+  def selection_anchor_at(_rel_y, _rel_x)
+    nil
+  end
 
   # Whether text is currently selected in this window.
   #
@@ -248,14 +263,14 @@ class BaseWindow < Curses::Window
 
   # Set the selection range and trigger a highlight redraw if supported.
   #
-  # @param start_y [Integer] starting row
+  # @param start_id [Integer] starting line ID
   # @param start_x [Integer] starting column
-  # @param end_y [Integer] ending row
+  # @param end_id [Integer] ending line ID
   # @param end_x [Integer] ending column
   # @return [void]
-  def highlight_selection(start_y, start_x, end_y, end_x)
-    @selection_start = [start_y, start_x]
-    @selection_end = [end_y, end_x]
+  def highlight_selection(start_id, start_x, end_id, end_x)
+    @selection_start = [start_id, start_x]
+    @selection_end = [end_id, end_x]
     redraw_with_highlight
   end
 
@@ -286,12 +301,12 @@ class BaseWindow < Curses::Window
   # Extract selected text from the buffer.
   # Subclasses override this with buffer-aware implementations.
   #
-  # @param _start_y [Integer] starting row
+  # @param _start_id [Integer] starting line ID
   # @param _start_x [Integer] starting column
-  # @param _end_y [Integer] ending row
+  # @param _end_id [Integer] ending line ID
   # @param _end_x [Integer] ending column
   # @return [String] the selected text (empty string by default)
-  def extract_selection(_start_y, _start_x, _end_y, _end_x)
+  def extract_selection(_start_id, _start_x, _end_id, _end_x)
     ''
   end
 
@@ -305,38 +320,34 @@ class BaseWindow < Curses::Window
     nil
   end
 
-  # Normalize selection coordinates so start is before end (top-left to bottom-right).
+  # Normalize selection coordinates so start is the older (topmost) endpoint.
   # Shared by TextWindow and TabbedTextWindow for selection extraction and rendering.
   #
-  # @param start_y [Integer] starting row
+  # @param start_id [Integer] starting line ID
   # @param start_x [Integer] starting column
-  # @param end_y [Integer] ending row
+  # @param end_id [Integer] ending line ID
   # @param end_x [Integer] ending column
-  # @return [Array<Integer>] normalized [start_y, start_x, end_y, end_x]
-  protected def normalize_selection(start_y, start_x, end_y, end_x)
-    if start_y > end_y || (start_y == end_y && start_x > end_x)
-      [end_y, end_x, start_y, start_x]
-    else
-      [start_y, start_x, end_y, end_x]
-    end
+  # @return [Array<Integer>] normalized [start_id, start_x, end_id, end_x]
+  protected def normalize_selection(start_id, start_x, end_id, end_x)
+    AnchoredSelection.normalize(start_id, start_x, end_id, end_x)
   end
 
   # Draw a single line with reverse-video highlighting for the selected region.
   # Shared by TextWindow and TabbedTextWindow for selection rendering.
   #
-  # @param y [Integer] the window row being drawn
+  # @param id [Integer] stable line ID of the line being drawn
   # @param line_text [String] full text of the line
   # @param line_colors [Array<Hash>] color regions for the line
-  # @param start_y [Integer] selection start row
+  # @param start_id [Integer] selection start line ID
   # @param start_x [Integer] selection start column
-  # @param end_y [Integer] selection end row
+  # @param end_id [Integer] selection end line ID
   # @param end_x [Integer] selection end column
   # @return [void]
-  protected def draw_line_with_selection(y, line_text, line_colors, start_y, start_x, end_y, end_x)
+  protected def draw_line_with_selection(id, line_text, line_colors, start_id, start_x, end_id, end_x)
     return if line_text.nil?
 
-    sel_start = y == start_y ? start_x : 0
-    sel_end = y == end_y ? end_x : line_text.length
+    sel_start = id == start_id ? start_x : 0
+    sel_end = id == end_id ? end_x : line_text.length
 
     if sel_start > 0
       pre_text = line_text[0...sel_start]

--- a/lib/windows/tabbed_text_window.rb
+++ b/lib/windows/tabbed_text_window.rb
@@ -35,6 +35,7 @@ class TabbedTextWindow < BaseWindow
     @tabs = {}              # { "main" => [[line, colors], ...], ... }
     @buffer_positions = {}  # Per-tab scroll positions
     @tab_activity = {}      # Track unread content in background tabs
+    @lines_appended = {}    # Per-tab monotonic append counters (stable line IDs)
     @active_tab = nil
     @max_buffer_size = DEFAULT_BUFFER_SIZE
     @indent_word_wrap = true
@@ -60,8 +61,18 @@ class TabbedTextWindow < BaseWindow
     @tabs[name] = []
     @buffer_positions[name] = 0
     @tab_activity[name] = false
+    @lines_appended[name] = 0
     @active_tab ||= name
     draw_tab_bar
+  end
+
+  # Monotonic count of lines ever appended to the active tab's buffer.
+  # Gives each buffer line a stable ID for selection anchoring
+  # (see {AnchoredSelection}).
+  #
+  # @return [Integer]
+  def lines_appended
+    @lines_appended[@active_tab] || 0
   end
 
   # Return the active tab's line buffer for TextWindow-compatible access.
@@ -87,6 +98,10 @@ class TabbedTextWindow < BaseWindow
     return unless @tabs.key?(name)
     return if name == @active_tab
 
+    # Selection line IDs are per-tab; a stale selection would map onto
+    # unrelated text in the new tab
+    @selection_start = nil
+    @selection_end = nil
     @active_tab = name
     @tab_activity[name] = false
     redraw
@@ -214,6 +229,7 @@ class TabbedTextWindow < BaseWindow
     effective_indent = indent.nil? ? @indent_word_wrap : indent
     wrap_text(string, content_width, string_colors, indent: effective_indent) do |line, line_colors|
       tab_buffer.unshift([line, line_colors])
+      @lines_appended[tab_name] += 1
       if tab_buffer.length > @max_buffer_size
         tab_buffer.pop
         max_pos = tab_buffer.length - content_height
@@ -311,6 +327,9 @@ class TabbedTextWindow < BaseWindow
         noutrefresh
       end
     end
+    # Selection is anchored to line IDs; re-render so the highlight
+    # follows its text to the new scroll position
+    redraw_with_highlight if has_highlight?
     update_scrollbar
   end
 
@@ -371,61 +390,44 @@ class TabbedTextWindow < BaseWindow
     @tabs[@active_tab] || []
   end
 
-  # Extract selected text from the active tab's buffer.
-  # Adjusts coordinates for the tab bar offset before indexing.
+  # Resolve window-relative coordinates to a stable [line_id, x] anchor
+  # in the active tab's buffer. Adjusts for the tab bar offset first.
   #
-  # @param start_y [Integer] starting row (window-relative)
+  # @param rel_y [Integer] row relative to window top (includes tab bar)
+  # @param rel_x [Integer] column relative to window left
+  # @return [Array<Integer>, nil] [line_id, x] anchor, or nil if the tab is empty
+  def selection_anchor_at(rel_y, rel_x)
+    tab_buffer = @tabs[@active_tab] || []
+    id = AnchoredSelection.id_at_row(rel_y - TAB_BAR_HEIGHT,
+                                     lines_appended: lines_appended,
+                                     buffer_pos: buffer_pos,
+                                     buffer_length: tab_buffer.length,
+                                     height: content_height)
+    id ? [id, [rel_x, 0].max] : nil
+  end
+
+  # Extract text from the active tab's buffer for a selection anchored
+  # to stable line IDs. Lines evicted past max_buffer_size are skipped.
+  #
+  # @param start_id [Integer] starting line ID
   # @param start_x [Integer] starting column
-  # @param end_y [Integer] ending row (window-relative)
+  # @param end_id [Integer] ending line ID
   # @param end_x [Integer] ending column
   # @return [String] the selected text, lines joined by newlines
-  def extract_selection(start_y, start_x, end_y, end_x)
-    start_y -= TAB_BAR_HEIGHT
-    end_y -= TAB_BAR_HEIGHT
-
-    return '' if start_y < 0 && end_y < 0
-
-    start_y = [start_y, 0].max
-    end_y = [end_y, 0].max
-
+  def extract_selection(start_id, start_x, end_id, end_x)
     tab_buffer = @tabs[@active_tab] || []
-    tab_buffer_pos = @buffer_positions[@active_tab] || 0
-    visible_lines = [tab_buffer.length - tab_buffer_pos, content_height].min
-    start_y, start_x, end_y, end_x = normalize_selection(start_y, start_x, end_y, end_x)
-
-    lines = []
-    (start_y..end_y).each do |y|
-      buffer_idx = tab_buffer_pos + (visible_lines - 1 - y)
-      next if buffer_idx >= tab_buffer.length || buffer_idx < 0
-
-      line_text = tab_buffer[buffer_idx][0] || ''
-      lines << if y == start_y && y == end_y
-                 line_text[start_x...end_x]
-               elsif y == start_y
-                 line_text[start_x..-1]
-               elsif y == end_y
-                 line_text[0...end_x]
-               else
-                 line_text
-               end
-    end
-    lines.join("\n")
+    AnchoredSelection.extract(tab_buffer, lines_appended, start_id, start_x, end_id, end_x)
   end
 
   # Redraw the active tab's content with reverse-video selection highlighting.
-  # Coordinates are window-relative (includes tab bar row).
+  # The selection is anchored to stable line IDs, so the highlight follows
+  # its text as new lines arrive or the user scrolls.
   #
   # @return [void]
   def redraw_with_highlight
     return unless @selection_start && @selection_end && @active_tab
 
-    start_y, start_x = @selection_start
-    end_y, end_x = @selection_end
-
-    # Adjust for tab bar and normalize
-    start_y -= TAB_BAR_HEIGHT
-    end_y -= TAB_BAR_HEIGHT
-    start_y, start_x, end_y, end_x = normalize_selection(start_y, start_x, end_y, end_x)
+    start_id, start_x, end_id, end_x = normalize_selection(*@selection_start, *@selection_end)
 
     tab_buffer = @tabs[@active_tab] || []
     tab_buffer_pos = @buffer_positions[@active_tab] || 0
@@ -440,9 +442,10 @@ class TabbedTextWindow < BaseWindow
       next if buffer_idx >= tab_buffer.length || buffer_idx < 0
 
       line_text, line_colors = tab_buffer[buffer_idx]
+      id = lines_appended - buffer_idx
 
-      if i >= start_y && i <= end_y
-        draw_line_with_selection(i, line_text, line_colors || [], start_y, start_x, end_y, end_x)
+      if id >= start_id && id <= end_id
+        draw_line_with_selection(id, line_text, line_colors || [], start_id, start_x, end_id, end_x)
       else
         add_line(line_text, line_colors || [])
       end

--- a/lib/windows/tabbed_text_window.rb
+++ b/lib/windows/tabbed_text_window.rb
@@ -227,8 +227,8 @@ class TabbedTextWindow < BaseWindow
     tab_buffer_pos = @buffer_positions[tab_name]
 
     effective_indent = indent.nil? ? @indent_word_wrap : indent
-    wrap_text(string, content_width, string_colors, indent: effective_indent) do |line, line_colors|
-      tab_buffer.unshift([line, line_colors])
+    wrap_text(string, content_width, string_colors, indent: effective_indent) do |line, line_colors, continuation|
+      tab_buffer.unshift([line, line_colors, continuation])
       @lines_appended[tab_name] += 1
       if tab_buffer.length > @max_buffer_size
         tab_buffer.pop
@@ -417,6 +417,22 @@ class TabbedTextWindow < BaseWindow
   def extract_selection(start_id, start_x, end_id, end_x)
     tab_buffer = @tabs[@active_tab] || []
     AnchoredSelection.extract(tab_buffer, lines_appended, start_id, start_x, end_id, end_x)
+  end
+
+  # Scroll one line when a drag pointer sits at the content area's top or
+  # bottom edge, extending a selection past the visible area. The top
+  # threshold is the tab bar row.
+  #
+  # @param rel_y [Integer] drag row relative to window top (includes tab bar)
+  # @return [Boolean] true if the view actually scrolled
+  def drag_auto_scroll(rel_y)
+    before = buffer_pos
+    if rel_y <= TAB_BAR_HEIGHT
+      scroll(-1)
+    elsif rel_y >= maxy - 1
+      scroll(1)
+    end
+    buffer_pos != before
   end
 
   # Redraw the active tab's content with reverse-video selection highlighting.

--- a/lib/windows/text_window.rb
+++ b/lib/windows/text_window.rb
@@ -20,12 +20,18 @@ class TextWindow < BaseWindow
   # @return [Boolean] whether a timestamp is appended to each non-empty line
   attr_accessor :time_stamp
 
+  # @return [Integer] monotonic count of lines ever appended to the buffer.
+  #   Gives each buffer line a stable ID for selection anchoring
+  #   (see {AnchoredSelection}).
+  attr_reader :lines_appended
+
   # Create a new scrollable text window.
   #
   # @param args [Array] arguments forwarded to {BaseWindow#initialize}
   def initialize(*args)
     @buffer = []
     @buffer_pos = 0
+    @lines_appended = 0
     @max_buffer_size = DEFAULT_BUFFER_SIZE
     @indent_word_wrap = true
     super
@@ -58,6 +64,7 @@ class TextWindow < BaseWindow
     effective_indent = indent.nil? ? @indent_word_wrap : indent
     wrap_text(string, maxx - 1, string_colors, indent: effective_indent) do |line, line_colors|
       @buffer.unshift([line, line_colors])
+      @lines_appended += 1
       @buffer.pop if @buffer.length > @max_buffer_size
       if @buffer_pos == 0
         addstr "\n" unless line.chomp.empty?
@@ -116,6 +123,9 @@ class TextWindow < BaseWindow
         noutrefresh
       end
     end
+    # Selection is anchored to line IDs; re-render so the highlight
+    # follows its text to the new scroll position
+    redraw_with_highlight if has_highlight?
     update_scrollbar
   end
 
@@ -145,46 +155,41 @@ class TextWindow < BaseWindow
     recent_line && recent_line[0] == prompt_text
   end
 
-  # Extract text from buffer for a selection region.
-  # Buffer is stored in reverse order: @buffer[0] = newest line.
-  # Text fills from the top of the window; visible_lines accounts for
-  # partially-filled buffers.
+  # Resolve window-relative coordinates to a stable [line_id, x] anchor.
+  # The anchor stays glued to the same text as the buffer grows or scrolls.
   #
-  # @param start_y [Integer] starting row (window-relative)
+  # @param rel_y [Integer] row relative to window top
+  # @param rel_x [Integer] column relative to window left
+  # @return [Array<Integer>, nil] [line_id, x] anchor, or nil if the buffer is empty
+  def selection_anchor_at(rel_y, rel_x)
+    id = AnchoredSelection.id_at_row(rel_y, lines_appended: @lines_appended,
+                                            buffer_pos: @buffer_pos,
+                                            buffer_length: @buffer.length,
+                                            height: maxy)
+    id ? [id, [rel_x, 0].max] : nil
+  end
+
+  # Extract text from the buffer for a selection anchored to stable line IDs.
+  # Lines evicted past max_buffer_size are skipped.
+  #
+  # @param start_id [Integer] starting line ID
   # @param start_x [Integer] starting column
-  # @param end_y [Integer] ending row (window-relative)
+  # @param end_id [Integer] ending line ID
   # @param end_x [Integer] ending column
   # @return [String] the selected text, lines joined by newlines
-  def extract_selection(start_y, start_x, end_y, end_x)
-    start_y, start_x, end_y, end_x = normalize_selection(start_y, start_x, end_y, end_x)
-    visible_lines = [@buffer.length - @buffer_pos, maxy].min
-
-    lines = []
-    (start_y..end_y).each do |y|
-      buffer_idx = @buffer_pos + (visible_lines - 1 - y)
-      next if buffer_idx >= @buffer.length || buffer_idx < 0
-
-      line_text = @buffer[buffer_idx][0] || ''
-      lines << if y == start_y && y == end_y
-                 line_text[start_x...end_x]
-               elsif y == start_y
-                 line_text[start_x..-1]
-               elsif y == end_y
-                 line_text[0...end_x]
-               else
-                 line_text
-               end
-    end
-    lines.join("\n")
+  def extract_selection(start_id, start_x, end_id, end_x)
+    AnchoredSelection.extract(@buffer, @lines_appended, start_id, start_x, end_id, end_x)
   end
 
   # Redraw all visible lines, applying reverse-video to the selected region.
+  # The selection is anchored to stable line IDs, so the highlight follows
+  # its text as new lines arrive or the user scrolls.
   #
   # @return [void]
   def redraw_with_highlight
     return unless @selection_start && @selection_end
 
-    start_y, start_x, end_y, end_x = normalize_selection(*@selection_start, *@selection_end)
+    start_id, start_x, end_id, end_x = normalize_selection(*@selection_start, *@selection_end)
     visible_lines = [@buffer.length - @buffer_pos, maxy].min
 
     (0...maxy).each do |y|
@@ -194,9 +199,10 @@ class TextWindow < BaseWindow
       next if buffer_idx >= @buffer.length || buffer_idx < 0
 
       line_text, line_colors = @buffer[buffer_idx]
+      id = @lines_appended - buffer_idx
 
-      if y >= start_y && y <= end_y
-        draw_line_with_selection(y, line_text, line_colors, start_y, start_x, end_y, end_x)
+      if id >= start_id && id <= end_id
+        draw_line_with_selection(id, line_text, line_colors, start_id, start_x, end_id, end_x)
       else
         add_line(line_text, line_colors)
       end

--- a/lib/windows/text_window.rb
+++ b/lib/windows/text_window.rb
@@ -62,8 +62,8 @@ class TextWindow < BaseWindow
   def add_string(string, string_colors = [], indent: nil)
     string += format_timestamp if @time_stamp && string && !string.chomp.empty?
     effective_indent = indent.nil? ? @indent_word_wrap : indent
-    wrap_text(string, maxx - 1, string_colors, indent: effective_indent) do |line, line_colors|
-      @buffer.unshift([line, line_colors])
+    wrap_text(string, maxx - 1, string_colors, indent: effective_indent) do |line, line_colors, continuation|
+      @buffer.unshift([line, line_colors, continuation])
       @lines_appended += 1
       @buffer.pop if @buffer.length > @max_buffer_size
       if @buffer_pos == 0
@@ -179,6 +179,21 @@ class TextWindow < BaseWindow
   # @return [String] the selected text, lines joined by newlines
   def extract_selection(start_id, start_x, end_id, end_x)
     AnchoredSelection.extract(@buffer, @lines_appended, start_id, start_x, end_id, end_x)
+  end
+
+  # Scroll one line when a drag pointer sits at the window's top or
+  # bottom edge, extending a selection past the visible area.
+  #
+  # @param rel_y [Integer] drag row relative to window top
+  # @return [Boolean] true if the view actually scrolled
+  def drag_auto_scroll(rel_y)
+    before = @buffer_pos
+    if rel_y <= 0
+      scroll(-1)
+    elsif rel_y >= maxy - 1
+      scroll(1)
+    end
+    @buffer_pos != before
   end
 
   # Redraw all visible lines, applying reverse-video to the selected region.

--- a/spec/lib/anchored_selection_spec.rb
+++ b/spec/lib/anchored_selection_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/anchored_selection'
+
+RSpec.describe AnchoredSelection do
+  # Build a newest-first buffer like TextWindow's: line N-1 appended last.
+  # buffer_for(3) => [["line 2", []], ["line 1", []], ["line 0", []]]
+  def buffer_for(count)
+    (0...count).map { |i| ["line #{i}", []] }.reverse
+  end
+
+  describe '.visible_lines' do
+    it 'is the window height when the buffer overflows the window' do
+      expect(described_class.visible_lines(100, 0, 10)).to eq(10)
+    end
+
+    it 'is the remaining line count when scrolled near the top' do
+      expect(described_class.visible_lines(100, 95, 10)).to eq(5)
+    end
+
+    it 'is the buffer length for a partially-filled window' do
+      expect(described_class.visible_lines(3, 0, 10)).to eq(3)
+    end
+
+    it 'is zero for an empty buffer' do
+      expect(described_class.visible_lines(0, 0, 10)).to eq(0)
+    end
+  end
+
+  describe '.id_at_row' do
+    it 'assigns the newest line (bottom row) the highest ID' do
+      # 5 lines, live view, height 10: rows 0..4 populated, row 4 is newest
+      id = described_class.id_at_row(4, lines_appended: 5, buffer_pos: 0, buffer_length: 5, height: 10)
+      expect(id).to eq(5)
+    end
+
+    it 'assigns the oldest visible line (top row) the lowest ID' do
+      id = described_class.id_at_row(0, lines_appended: 5, buffer_pos: 0, buffer_length: 5, height: 10)
+      expect(id).to eq(1)
+    end
+
+    it 'returns nil for an empty buffer' do
+      expect(described_class.id_at_row(0, lines_appended: 0, buffer_pos: 0, buffer_length: 0, height: 10)).to be_nil
+    end
+
+    it 'clamps rows below the populated area to the newest line' do
+      # 3 lines in a 10-row window: rows 3..9 are blank; clicking there
+      # anchors to the last real line instead of failing
+      id = described_class.id_at_row(9, lines_appended: 3, buffer_pos: 0, buffer_length: 3, height: 10)
+      expect(id).to eq(3)
+    end
+
+    it 'clamps negative rows (drag above the window) to the top line' do
+      id = described_class.id_at_row(-2, lines_appended: 20, buffer_pos: 0, buffer_length: 20, height: 10)
+      expect(id).to eq(described_class.id_at_row(0, lines_appended: 20, buffer_pos: 0, buffer_length: 20, height: 10))
+    end
+
+    it 'accounts for scroll position' do
+      # 20 lines, height 10, scrolled up 5: bottom row shows index 5
+      id = described_class.id_at_row(9, lines_appended: 20, buffer_pos: 5, buffer_length: 20, height: 10)
+      expect(id).to eq(15)
+    end
+
+    it 'is stable across appends: the same text keeps its ID as rows shift' do
+      before = described_class.id_at_row(9, lines_appended: 20, buffer_pos: 0, buffer_length: 20, height: 10)
+      # 3 new lines arrive; the line that was on row 9 is now on row 6
+      after = described_class.id_at_row(6, lines_appended: 23, buffer_pos: 0, buffer_length: 23, height: 10)
+      expect(after).to eq(before)
+    end
+  end
+
+  describe '.row_of_id' do
+    it 'round-trips with id_at_row in a live view' do
+      (0...10).each do |row|
+        id = described_class.id_at_row(row, lines_appended: 20, buffer_pos: 0, buffer_length: 20, height: 10)
+        expect(described_class.row_of_id(id, lines_appended: 20, buffer_pos: 0, buffer_length: 20, height: 10)).to eq(row)
+      end
+    end
+
+    it 'round-trips while scrolled' do
+      id = described_class.id_at_row(3, lines_appended: 50, buffer_pos: 12, buffer_length: 50, height: 10)
+      expect(described_class.row_of_id(id, lines_appended: 50, buffer_pos: 12, buffer_length: 50, height: 10)).to eq(3)
+    end
+
+    it 'returns nil when the line has scrolled off the bottom of the view' do
+      # ID 20 is the newest line; scrolled up 15, it is below the viewport
+      expect(described_class.row_of_id(20, lines_appended: 20, buffer_pos: 15, buffer_length: 20, height: 10)).to be_nil
+    end
+
+    it 'returns nil when the line is above the top of the view' do
+      # ID 1 is the oldest of 20 lines; a 5-row live view shows only IDs 16..20
+      expect(described_class.row_of_id(1, lines_appended: 20, buffer_pos: 0, buffer_length: 20, height: 5)).to be_nil
+    end
+
+    it 'returns nil for an evicted line' do
+      # 30 appended but only 20 retained: IDs 1..10 are gone
+      expect(described_class.row_of_id(5, lines_appended: 30, buffer_pos: 0, buffer_length: 20, height: 10)).to be_nil
+    end
+  end
+
+  describe '.normalize' do
+    it 'keeps an already-ordered selection unchanged' do
+      expect(described_class.normalize(3, 2, 5, 7)).to eq([3, 2, 5, 7])
+    end
+
+    it 'swaps endpoints when dragged upward' do
+      expect(described_class.normalize(5, 7, 3, 2)).to eq([3, 2, 5, 7])
+    end
+
+    it 'swaps columns when dragged right-to-left on one line' do
+      expect(described_class.normalize(4, 9, 4, 2)).to eq([4, 2, 4, 9])
+    end
+  end
+
+  describe '.extract' do
+    let(:buffer) { buffer_for(5) } # IDs 1..5, "line 0" (oldest, ID 1) .. "line 4" (newest, ID 5)
+
+    it 'extracts a single-line span' do
+      expect(described_class.extract(buffer, 5, 2, 0, 2, 4)).to eq('line')
+    end
+
+    it 'extracts a multi-line span with partial first and last lines' do
+      text = described_class.extract(buffer, 5, 2, 5, 4, 4)
+      expect(text).to eq("1\nline 2\nline")
+    end
+
+    it 'extracts the same text regardless of drag direction' do
+      down = described_class.extract(buffer, 5, 2, 5, 4, 4)
+      up = described_class.extract(buffer, 5, 4, 4, 2, 5)
+      expect(up).to eq(down)
+    end
+
+    it 'still extracts the anchored text after new lines are appended' do
+      # Select "line 3" (ID 4) end-to-end, then 10 lines arrive
+      grown = (5...15).map { |i| ["line #{i}", []] }.reverse + buffer
+      expect(described_class.extract(grown, 15, 4, 0, 4, 6)).to eq('line 3')
+    end
+
+    it 'skips lines evicted past the buffer cap' do
+      # IDs 1..2 evicted: buffer holds IDs 3..5 of 5 appended
+      trimmed = buffer_for(5).first(3)
+      expect(described_class.extract(trimmed, 5, 1, 0, 3, 6)).to eq('line 2')
+    end
+
+    it 'skips IDs newer than anything appended' do
+      expect(described_class.extract(buffer, 5, 5, 0, 99, 6)).to eq('line 4')
+    end
+
+    it 'clamps columns past the end of a line' do
+      expect(described_class.extract(buffer, 5, 3, 2, 3, 500)).to eq('ne 2')
+    end
+
+    it 'returns empty when the start column is past the end of a single-line span' do
+      expect(described_class.extract(buffer, 5, 3, 500, 3, 900)).to eq('')
+    end
+
+    it 'returns empty for an entirely evicted span' do
+      trimmed = buffer_for(5).first(2)
+      expect(described_class.extract(trimmed, 5, 1, 0, 2, 6)).to eq('')
+    end
+
+    it 'treats a nil line text as empty rather than crashing' do
+      with_nil = [[nil, []]] + buffer
+      expect(described_class.extract(with_nil, 6, 5, 0, 6, 3)).to eq("line 4\n")
+    end
+  end
+end

--- a/spec/lib/anchored_selection_spec.rb
+++ b/spec/lib/anchored_selection_spec.rb
@@ -164,4 +164,99 @@ RSpec.describe AnchoredSelection do
       expect(described_class.extract(with_nil, 6, 5, 0, 6, 3)).to eq("line 4\n")
     end
   end
+
+  describe '.extract with wrap continuations' do
+    # A logical line wrapped to three display lines (indent adds 2 spaces,
+    # StyledText#wrap keeps the break space on the previous line), then a
+    # separate unwrapped line. Newest first, IDs 1..4.
+    let(:wrapped) do
+      [
+        ['Next line', [], false],           # ID 4
+        ['  the lazy dog', [], true],       # ID 3
+        ['  fox jumps over ', [], true],    # ID 2
+        ['The quick brown ', [], false]     # ID 1
+      ]
+    end
+
+    it 'rejoins wrapped display lines into one logical line' do
+      text = described_class.extract(wrapped, 4, 1, 0, 4, 9)
+      expect(text).to eq("The quick brown fox jumps over the lazy dog\nNext line")
+    end
+
+    it 'joins partial pieces across a wrap boundary' do
+      text = described_class.extract(wrapped, 4, 2, 2, 3, 8)
+      expect(text).to eq('fox jumps over the la')
+    end
+
+    it 'does not join when the selection starts on a continuation line' do
+      text = described_class.extract(wrapped, 4, 3, 0, 4, 4)
+      expect(text).to eq("  the lazy dog\nNext")
+    end
+
+    it 'rejoins a hard mid-word break seamlessly' do
+      hard = [['  efgh', [], true], ['abcd', [], false]]
+      expect(described_class.extract(hard, 2, 1, 0, 2, 6)).to eq('abcdefgh')
+    end
+
+    it 'keeps a continuation intact when its wrap start was evicted' do
+      trimmed = wrapped.first(3) # ID 1 ("The quick brown ") evicted
+      text = described_class.extract(trimmed, 4, 1, 0, 4, 9)
+      expect(text).to eq("  fox jumps over the lazy dog\nNext line")
+    end
+  end
+
+  describe '.word_span' do
+    let(:line) { 'get #40872332 from pack' }
+
+    it 'spans the whitespace-delimited word under the column' do
+      expect(described_class.word_span(line, 7)).to eq([4, 13])
+      expect(line[4...13]).to eq('#40872332')
+    end
+
+    it 'spans a word from its first and last characters' do
+      expect(described_class.word_span(line, 0)).to eq([0, 3])
+      expect(described_class.word_span(line, 2)).to eq([0, 3])
+    end
+
+    it 'returns nil on whitespace' do
+      expect(described_class.word_span(line, 3)).to be_nil
+    end
+
+    it 'returns nil for an empty or nil line' do
+      expect(described_class.word_span('', 0)).to be_nil
+      expect(described_class.word_span(nil, 0)).to be_nil
+    end
+
+    it 'clamps a column past the end of the line to the last word' do
+      expect(described_class.word_span(line, 500)).to eq([19, 23])
+    end
+  end
+
+  describe '.logical_line_span' do
+    let(:wrapped) do
+      [
+        ['Next line', [], false],           # ID 4
+        ['  the lazy dog', [], true],       # ID 3
+        ['  fox jumps over ', [], true],    # ID 2
+        ['The quick brown ', [], false]     # ID 1
+      ]
+    end
+
+    it 'expands from a middle continuation to the full logical line' do
+      expect(described_class.logical_line_span(wrapped, 4, 2)).to eq([1, 3])
+    end
+
+    it 'expands from the first display line forward' do
+      expect(described_class.logical_line_span(wrapped, 4, 1)).to eq([1, 3])
+    end
+
+    it 'returns the line itself for an unwrapped line' do
+      expect(described_class.logical_line_span(wrapped, 4, 4)).to eq([4, 4])
+    end
+
+    it 'stops the backward walk at an evicted line' do
+      trimmed = wrapped.first(3) # ID 1 evicted
+      expect(described_class.logical_line_span(trimmed, 4, 3)).to eq([2, 3])
+    end
+  end
 end

--- a/spec/lib/mouse_scroll_spec.rb
+++ b/spec/lib/mouse_scroll_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Tests MouseScroll click-resolution handling around .select / .draghl
+# toggles. Focused on the mouseinterval save/restore path: the curses gem's
+# Curses.mouseinterval returns a boolean (whether the interval was set), NOT
+# the previous interval, and it raises TypeError if handed a non-Integer.
+# The stub below models that faithfully so the toggle-off path is exercised
+# against real gem semantics rather than a lenient Integer-returning stub.
+
+require_relative '../../spec/spec_helper'
+require_relative '../../lib/mouse_scroll'
+
+RSpec.describe MouseScroll do
+  let(:key_action) { {} }
+  let(:display_fn) { ->(_msg) {} }
+
+  # Records every argument passed to Curses.mouseinterval and mimics the real
+  # curses 1.6.0 binding: NUM2INT(arg) raises on a non-Integer, and the return
+  # is a boolean, never the previous interval.
+  let(:mouseinterval_args) { [] }
+
+  before do
+    allow(ProfanitySettings).to receive(:load_setting).and_return(true)
+    allow(ProfanitySettings).to receive(:load_mouse_settings).and_return(nil)
+    allow(ProfanitySettings).to receive(:save_setting)
+
+    allow(Curses).to receive(:mousemask)
+    allow(Curses).to receive(:mouseinterval) do |arg|
+      unless arg.is_a?(Integer)
+        raise TypeError, "no implicit conversion of #{arg.class} into Integer"
+      end
+
+      mouseinterval_args << arg
+      true
+    end
+  end
+
+  subject(:mouse) { described_class.new(key_action, display_fn) }
+
+  describe 'click-resolution save/restore' do
+    it 'suppresses with interval 0 when enabling click events with drag highlight' do
+      mouse.enable_click_events
+      expect(mouseinterval_args).to eq([0])
+    end
+
+    it 'restores an Integer interval (not the boolean return) when disabling' do
+      mouse.enable_click_events
+      expect { mouse.disable_click_events }.not_to raise_error
+      expect(mouseinterval_args).to eq([0, MouseScroll::DEFAULT_MOUSEINTERVAL])
+    end
+
+    it 'restores click resolution when drag highlight is toggled off while active' do
+      mouse.enable_click_events
+      mouseinterval_args.clear
+      expect { mouse.drag_highlight = false }.not_to raise_error
+      expect(mouseinterval_args).to eq([MouseScroll::DEFAULT_MOUSEINTERVAL])
+    end
+
+    it 'suppresses again when drag highlight is toggled back on while active' do
+      mouse.enable_click_events
+      mouse.drag_highlight = false
+      mouseinterval_args.clear
+      expect { mouse.drag_highlight = true }.not_to raise_error
+      expect(mouseinterval_args).to eq([0])
+    end
+
+    it 'does not restore when nothing was suppressed (drag highlight off from the start)' do
+      allow(ProfanitySettings).to receive(:load_setting).and_return(false)
+      mouse.enable_click_events # drag highlight off -> no suppression
+      expect(mouseinterval_args).to be_empty
+      expect { mouse.disable_click_events }.not_to raise_error
+      expect(mouseinterval_args).to be_empty
+    end
+  end
+end

--- a/spec/lib/selection_manager_spec.rb
+++ b/spec/lib/selection_manager_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/anchored_selection'
+require_relative '../../lib/selection_manager'
+
+# Minimal stand-in for TextWindow's selection surface: a newest-first
+# buffer, a monotonic append counter, and the same AnchoredSelection
+# delegation the real windows use. Lets us drive press/drag/release
+# against a mutating buffer without curses.
+class FakeBufferWindow
+  attr_reader :buffer, :lines_appended, :highlights
+
+  def initialize(height:)
+    @height = height
+    @buffer = []
+    @lines_appended = 0
+    @buffer_pos = 0
+    @highlights = []
+  end
+
+  def add_line(text)
+    @buffer.unshift([text, []])
+    @lines_appended += 1
+  end
+
+  def evict_to(count)
+    @buffer.pop while @buffer.length > count
+  end
+
+  def selection_anchor_at(rel_y, rel_x)
+    id = AnchoredSelection.id_at_row(rel_y, lines_appended: @lines_appended,
+                                            buffer_pos: @buffer_pos,
+                                            buffer_length: @buffer.length,
+                                            height: @height)
+    id ? [id, [rel_x, 0].max] : nil
+  end
+
+  def extract_selection(start_id, start_x, end_id, end_x)
+    AnchoredSelection.extract(@buffer, @lines_appended, start_id, start_x, end_id, end_x)
+  end
+
+  def highlight_selection(start_id, start_x, end_id, end_x)
+    @highlights << [start_id, start_x, end_id, end_x]
+  end
+
+  def clear_highlight; end
+end
+
+RSpec.describe SelectionManager do
+  let(:window) { FakeBufferWindow.new(height: 10) }
+  let(:copied) { [] }
+
+  before do
+    described_class.clear_selection
+    allow(described_class).to receive(:copy_to_clipboard) { |text| copied << text }
+  end
+
+  after { described_class.clear_selection }
+
+  def fill(window, count)
+    count.times { |i| window.add_line("line #{i}") }
+  end
+
+  it 'copies the text under the cursor for a simple drag' do
+    fill(window, 10) # rows 0..9 show "line 0".."line 9"
+    described_class.start_selection(window, 3, 0)
+    described_class.update_selection(3, 6)
+    described_class.end_selection
+    expect(copied).to eq(['line 3'])
+  end
+
+  it 'copies the pressed-on text even when new lines arrive mid-drag' do
+    fill(window, 10)
+    described_class.start_selection(window, 9, 0) # press on "line 9", bottom row
+    3.times { |i| window.add_line("new #{i}") }   # "line 9" moves up to row 6
+    described_class.update_selection(6, 6)        # release where it moved to
+    described_class.end_selection
+    expect(copied).to eq(['line 9'])
+  end
+
+  it 'anchors at press time, not release time' do
+    fill(window, 10)
+    described_class.start_selection(window, 9, 0)
+    window.add_line('intruder')
+    # Release on the same screen row the press landed on — which now
+    # shows different text. The selection must span from the pressed
+    # line to the line now under the cursor, not silently re-target.
+    described_class.update_selection(9, 8)
+    described_class.end_selection
+    expect(copied).to eq(["line 9\nintruder"])
+  end
+
+  it 'copies nothing when the anchored lines have been evicted' do
+    fill(window, 10)
+    described_class.start_selection(window, 0, 0) # oldest line
+    described_class.update_selection(0, 6)
+    window.evict_to(5) # "line 0".."line 4" evicted
+    described_class.end_selection
+    expect(copied).to be_empty
+  end
+
+  it 'does not start a selection on an empty window' do
+    described_class.start_selection(window, 3, 0)
+    described_class.update_selection(5, 5)
+    described_class.end_selection
+    expect(copied).to be_empty
+    expect(window.highlights).to be_empty
+  end
+
+  it 'ignores windows without a selection surface' do
+    plain = Object.new
+    def plain.selection_anchor_at(_y, _x) = nil
+    def plain.clear_highlight; end
+    described_class.start_selection(plain, 1, 1)
+    described_class.update_selection(2, 2)
+    described_class.end_selection
+    expect(copied).to be_empty
+  end
+
+  it 'keeps raw press coordinates for the click-vs-drag heuristic' do
+    fill(window, 10)
+    described_class.start_selection(window, 4, 7)
+    window.add_line('shift')
+    expect(described_class.start_pos).to eq([4, 7])
+  end
+
+  it 'highlights with anchored IDs while dragging' do
+    fill(window, 10)
+    described_class.start_selection(window, 3, 2) # "line 3" => ID 4
+    described_class.update_selection(5, 6)        # "line 5" => ID 6
+    expect(window.highlights.last).to eq([4, 2, 6, 6])
+  end
+end

--- a/spec/lib/selection_manager_spec.rb
+++ b/spec/lib/selection_manager_spec.rb
@@ -18,9 +18,13 @@ class FakeBufferWindow
     @highlights = []
   end
 
-  def add_line(text)
-    @buffer.unshift([text, []])
+  def add_line(text, continuation: false)
+    @buffer.unshift([text, [], continuation])
     @lines_appended += 1
+  end
+
+  def buffer_content
+    @buffer
   end
 
   def evict_to(count)
@@ -129,5 +133,88 @@ RSpec.describe SelectionManager do
     described_class.start_selection(window, 3, 2) # "line 3" => ID 4
     described_class.update_selection(5, 6)        # "line 5" => ID 6
     expect(window.highlights.last).to eq([4, 2, 6, 6])
+  end
+
+  it 'reports the number of characters copied' do
+    fill(window, 10)
+    described_class.start_selection(window, 3, 0)
+    described_class.update_selection(3, 6)
+    expect(described_class.end_selection).to eq(6)
+  end
+
+  describe 'live drag throttling' do
+    it 'coalesces a motion flood into interval-spaced redraws' do
+      fill(window, 10)
+      described_class.start_selection(window, 0, 0, now: 0.0)
+      redraws = [0.001, 0.002, 0.003, 0.06, 0.07, 0.13].map.with_index do |t, i|
+        described_class.drag_update(1 + i, 2, now: t)
+      end
+      # First motion redraws; the rest only when 50ms have passed
+      expect(redraws).to eq([true, false, false, true, false, true])
+    end
+
+    it 'records the drag position even when the redraw is throttled' do
+      fill(window, 10)
+      described_class.start_selection(window, 0, 0, now: 0.0)
+      described_class.drag_update(1, 2, now: 0.001)
+      described_class.drag_update(5, 7, now: 0.002) # throttled
+      expect(described_class.last_drag_pos).to eq([5, 7])
+    end
+
+    it 'does nothing without an anchored selection' do
+      expect(described_class.drag_update(1, 1, now: 0.0)).to be(false)
+    end
+  end
+
+  describe 'multi-click selection' do
+    it 'double-click selects the word under the cursor' do
+      window.add_line('get #40872332 from pack') # row 0
+      described_class.start_selection(window, 0, 7, now: 0.0)
+      expanded = described_class.start_selection(window, 0, 7, now: 0.2)
+      expect(expanded).to be(true)
+      expect(described_class.multi_click_selected?).to be(true)
+      described_class.end_selection
+      expect(copied).to eq(['#40872332'])
+    end
+
+    it 'triple-click selects the whole logical (unwrapped) line' do
+      window.add_line('The quick brown ')
+      window.add_line('  fox jumps', continuation: true) # rows 0..1
+      3.times { |i| described_class.start_selection(window, 1, 3, now: i * 0.1) }
+      expect(described_class.multi_click_selected?).to be(true)
+      described_class.end_selection
+      expect(copied).to eq(['The quick brown fox jumps'])
+    end
+
+    it 'does not expand when the second click is too slow' do
+      window.add_line('get #40872332 from pack')
+      described_class.start_selection(window, 0, 7, now: 0.0)
+      described_class.start_selection(window, 0, 7, now: 1.0)
+      expect(described_class.multi_click_selected?).to be(false)
+    end
+
+    it 'does not expand when the clicks land apart' do
+      window.add_line('get #40872332 from pack')
+      described_class.start_selection(window, 0, 7, now: 0.0)
+      described_class.start_selection(window, 0, 15, now: 0.1)
+      expect(described_class.multi_click_selected?).to be(false)
+    end
+
+    it 'does not expand a double-click on whitespace' do
+      window.add_line('a b')
+      described_class.start_selection(window, 0, 1, now: 0.0)
+      expanded = described_class.start_selection(window, 0, 1, now: 0.1)
+      expect(expanded).to be(false)
+      expect(described_class.multi_click_selected?).to be(false)
+    end
+  end
+
+  it 'copies wrapped display lines as one logical line' do
+    window.add_line('The quick brown ')
+    window.add_line('  fox jumps', continuation: true)
+    described_class.start_selection(window, 0, 0)
+    described_class.update_selection(1, 11)
+    described_class.end_selection
+    expect(copied).to eq(['The quick brown fox jumps'])
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,7 @@ module Curses
   BUTTON1_PRESSED = 0x2
   BUTTON1_RELEASED = 0x4
   BUTTON1_CLICKED = 0x8
+  REPORT_MOUSE_POSITION = 0x8000000
 
   def self.color_pair(_id) = 0
   def self.lines = 24
@@ -50,6 +51,7 @@ module Curses
   def self.doupdate = nil
   def self.use_default_colors = nil
   def self.mousemask(*) = nil
+  def self.mouseinterval(*) = 166
   def self.getmouse = nil
   def self.close_screen = nil
   def self.init_screen = nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,7 +51,15 @@ module Curses
   def self.doupdate = nil
   def self.use_default_colors = nil
   def self.mousemask(*) = nil
-  def self.mouseinterval(*) = 166
+
+  # Models the real curses 1.6.0 binding: NUM2INT raises on non-Integer
+  # args, and the return is a boolean — never the previous interval.
+  def self.mouseinterval(interval)
+    raise TypeError, "no implicit conversion of #{interval.class} into Integer" unless interval.is_a?(Integer)
+
+    true
+  end
+
   def self.getmouse = nil
   def self.close_screen = nil
   def self.init_screen = nil


### PR DESCRIPTION
## Summary

Two commits that overhaul mouse text selection, reviewable independently:

1. `fix(selection)`: anchor selections to stable buffer line IDs — the correctness fix
2. `feat(selection)`: live drag highlight, double/triple-click, edge auto-scroll, unwrapped copy, `.select` / `.draghl` toggles

## 1. Buffer-anchored selection (correctness)

Selections were stored as **screen rows**, but the line buffer is unshift-based — newest line at index 0 — so every line that arrived between press and release shifted the buffer underneath the selection. On release, the stored rows resolved to different text than the user dragged over, and the wrong lines were silently copied. In an active game window this hit most multi-line selections.

- Each buffer gets a monotonic `lines_appended` counter, giving every line a **stable ID** (`id = lines_appended - buffer_index`), recoverable in both directions at any time.
- Press/drag positions resolve to `(line_id, column)` anchors immediately; rendering and extraction convert back at use time, so the selection stays glued to its text through incoming output and scrolling. Evicted lines are skipped; columns clamp.
- `TabbedTextWindow` gets per-tab counters; tab switches clear the selection.
- Raw press coordinates are kept separately for the click-vs-drag heuristic (deliberately screen-based so link clicks work while text streams).
- The math lives in a pure `AnchoredSelection` module (no curses), same pattern as `StyledText`.

## 2. Live drag highlight + polish

**Live drag highlight.** Pointer-motion reporting is added to the mouse mask *only while button 1 is held* — a permanent `REPORT_MOUSE_POSITION` stream is what corrupted the display when this was tried before ([mouse_scroll.rb's old comment]). Redraws are throttled to one per 50ms so motion floods coalesce. `mouseinterval(0)` disables ncurses click synthesis while capture is on; the existing click-vs-drag heuristic takes over. **Toggle: `.draghl`**, persisted to `settings.json`, default on — off restores the previous highlight-on-release behavior exactly, as the safe fallback for terminals that misbehave with motion reporting.

**Edge auto-scroll.** Holding a drag at a window's top/bottom edge scrolls one line per input-loop tick (~100ms) and extends the selection — trivial now that endpoints are anchored.

**Double/triple-click.** Detected from press timestamps (click synthesis is off), double-click selects the whitespace-delimited word, triple-click the whole logical line including wrap continuations.

**Unwrapped copy.** `wrap_text` flags continuation lines in the buffer; extraction rejoins them (previous line keeps its break space, the continuation's artificial indent is stripped), so pasted text has no mid-sentence hard wraps.

**`.select` toggle.** Drag-to-select without clickable links; mouse capture is on when either `.links` or `.select` is. `dispatch_link` now checks `blue_links` so stale cmd runs can't fire in selection-only mode. `save_mouse_settings` merges into `settings.json` instead of clobbering other keys.

**Feedback.** A brief `* [copied N chars]` line in the main window after each copy.

## Tests

61 new examples across `anchored_selection_spec` and `selection_manager_spec`: row↔ID round-trips under appends/scroll/eviction, mid-drag appends copying the pressed-on text, drag-direction normalization, redraw throttling (clock-injected), double/triple-click counting and expansion, continuation rejoining including evicted wrap starts.

`bundle exec rspec`: 798 examples, 2 failures — both pre-existing on `main` (`window_manager_subscribe_spec` `SpyIndicatorWindow#value`, unrelated). `bundle exec rubocop` clean on all touched files.

## Caveats for review

- Live drag highlight is the one piece with terminal-emulator variability (kitty/alacritty/wezterm/tmux handle motion reporting differently). It degrades gracefully: `.draghl` off = exactly the old behavior, and builds without `REPORT_MOUSE_POSITION` never request motion.
- USER_GUIDE updated for all of the above.