### PR TITLE
Add multi-line gag patterns

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1230,7 +1230,7 @@ Combine with the DOCTYPE entity definitions for readable color names:
 ## 6. Gag Patterns
 
 Gag patterns suppress (hide) lines that match a regular expression. There are
-two types:
+three types:
 
 ### General Gag Patterns
 
@@ -1249,6 +1249,26 @@ combat messages.
 ```xml
 <combat_gag>REGEX_PATTERN</combat_gag>
 ```
+
+### Multi-line Gag Patterns
+
+Suppress a whole block of lines, not just one. When a line matches the `start`
+pattern, that line and every following line are dropped until the block ends.
+
+```xml
+<multiline_gag start="REGEX_PATTERN" end="REGEX_PATTERN"/>
+```
+
+- `start` (required) is the regex that begins the block. The matching line is
+  suppressed.
+- `end` (optional) is the regex that ends the block. The line matching `end`
+  is also suppressed, and normal display resumes on the next line.
+- If `end` is omitted, the block is **prompt-terminated**: it ends at the next
+  game prompt (the prompt itself is unaffected). This suits messages that are
+  always followed by a prompt, such as sanowret crystal knowledge.
+
+A safety cap releases any block that runs longer than 100 suppressed lines, so
+a mistyped `end` pattern can never swallow the stream indefinitely.
 
 ### Examples
 
@@ -1270,6 +1290,12 @@ combat messages.
 
 <!-- Hide specific creature ambient text -->
 <combat_gag>^An? \w+ (hisses|growls|snarls) menacingly\.</combat_gag>
+
+<!-- Hide sanowret crystal knowledge (header + body), ending at the prompt -->
+<multiline_gag start="^Knowledge from your sanowret crystal about .* rings clear in your mind:"/>
+
+<!-- Hide a block bounded by explicit start and end lines -->
+<multiline_gag start="^You begin to read the tattered scroll\." end="^The scroll crumbles to dust\."/>
 ```
 
 ### Notes
@@ -1277,6 +1303,7 @@ combat messages.
 - Gag patterns use Ruby regular expression syntax.
 - General gags are checked before any text processing or routing.
 - Combat gags are checked only for lines in the combat stream.
+- Multi-line gags are checked before general gags, at the raw-line level.
 - On `.reload`, custom gag patterns from XML are reloaded (defaults are
   preserved).
 - Invalid regex patterns are logged as warnings and skipped.

--- a/lib/gag_patterns.rb
+++ b/lib/gag_patterns.rb
@@ -5,17 +5,26 @@
 
 # Manages gag patterns that filter unwanted text from the display.
 # Patterns can be loaded from the XML config file or added programmatically.
-# Maintains two separate pattern sets: general (all streams) and combat.
+# Maintains three pattern sets: general (all streams, single line), combat
+# (single line), and multi-line (a start pattern that suppresses a block of
+# lines until an end pattern or the next game prompt).
 #
 # @example
 #   GagPatterns.load_defaults
 #   GagPatterns.add_general_pattern('You also see .* moth')
 #   GagPatterns.general_regexp  # => /(?-mix:You also see .* moth)/
+#
+# @example Multi-line gag
+#   GagPatterns.add_multiline_gag('Knowledge from your sanowret crystal')
+#   GagPatterns.match_multiline_start('Knowledge from your sanowret crystal ...')
+#   # => { start: /.../, end: nil }
 module GagPatterns
   @combat_patterns = []
   @general_patterns = []
+  @multiline_gags = []
   @combat_regexp = nil
   @general_regexp = nil
+  @multiline_start_regexp = nil
 
   class << self
     # @return [Regexp] combined regexp matching any combat gag pattern
@@ -24,12 +33,16 @@ module GagPatterns
     # @return [Regexp] combined regexp matching any general gag pattern
     attr_reader :general_regexp
 
+    # @return [Array<Hash>] multi-line gag definitions, each { start:, end: }
+    attr_reader :multiline_gags
+
     # Initialize with default patterns (empty). Call at startup.
     #
     # @return [void]
     def load_defaults
       @combat_patterns = default_combat_patterns.dup
       @general_patterns = default_general_patterns.dup
+      @multiline_gags = default_multiline_gags.dup
       rebuild_regexps
     end
 
@@ -59,6 +72,42 @@ module GagPatterns
       warn "Invalid gag pattern: #{pattern} - #{e.message}"
     end
 
+    # Add a multi-line gag. When a line matches +start_pattern+, that line
+    # and every following line are suppressed until either +end_pattern+
+    # matches (that end line is also suppressed) or, if no end pattern is
+    # given, the next game prompt is reached (the prompt is not suppressed).
+    #
+    # @param start_pattern [String, Regexp] pattern that begins the block
+    # @param end_pattern [String, Regexp, nil] optional pattern that ends the
+    #   block; when nil the block is terminated by the next prompt
+    # @return [void]
+    # @raise [RegexpError] logged as warning if a pattern string is invalid
+    def add_multiline_gag(start_pattern, end_pattern = nil)
+      start_regexp = start_pattern.is_a?(Regexp) ? start_pattern : Regexp.new(start_pattern)
+      end_regexp = nil
+      if end_pattern && !end_pattern.to_s.strip.empty?
+        end_regexp = end_pattern.is_a?(Regexp) ? end_pattern : Regexp.new(end_pattern)
+      end
+      @multiline_gags << { start: start_regexp, end: end_regexp }
+      rebuild_regexps
+    rescue RegexpError => e
+      warn "Invalid multiline gag pattern: #{start_pattern} / #{end_pattern} - #{e.message}"
+    end
+
+    # Find the multi-line gag whose start pattern matches the given line.
+    #
+    # A union regexp is checked first as a fast reject so the common
+    # no-match case costs a single match instead of one per gag.
+    #
+    # @param line [String] raw server line to test
+    # @return [Hash, nil] the matching { start:, end: } gag, or nil
+    def match_multiline_start(line)
+      return nil if @multiline_gags.empty?
+      return nil unless line.match?(@multiline_start_regexp)
+
+      @multiline_gags.find { |gag| line.match?(gag[:start]) }
+    end
+
     # Reset to default patterns, discarding any custom patterns.
     # Called during settings reload to re-apply patterns from XML.
     #
@@ -66,6 +115,7 @@ module GagPatterns
     def clear_custom
       @combat_patterns = default_combat_patterns.dup
       @general_patterns = default_general_patterns.dup
+      @multiline_gags = default_multiline_gags.dup
       rebuild_regexps
     end
 
@@ -78,6 +128,7 @@ module GagPatterns
     def rebuild_regexps
       @combat_regexp = Regexp.union(@combat_patterns)
       @general_regexp = Regexp.union(@general_patterns)
+      @multiline_start_regexp = Regexp.union(@multiline_gags.map { |gag| gag[:start] })
     end
 
     # @return [Array<Regexp>] default combat gag patterns (empty)
@@ -89,6 +140,12 @@ module GagPatterns
     # @return [Array<Regexp>] default general gag patterns (empty)
     # @api private
     def default_general_patterns
+      []
+    end
+
+    # @return [Array<Hash>] default multi-line gags (empty)
+    # @api private
+    def default_multiline_gags
       []
     end
   end

--- a/lib/game_text_processor.rb
+++ b/lib/game_text_processor.rb
@@ -52,6 +52,11 @@ class GameTextProcessor
   # Movement verbs that suppress the following prompt and empty line.
   MOVEMENT_PATTERN = /^You (?:run|walk|go|swim|climb|crawl|drag|stride|sneak|stalk)\b/
 
+  # Safety cap: a multi-line gag whose end pattern (or prompt) never arrives
+  # is released after this many suppressed lines so it cannot swallow the
+  # stream. Real blocks (e.g. sanowret crystal knowledge) are 2-3 lines.
+  MULTILINE_GAG_MAX_LINES = 100
+
   # Precomputed merged logon patterns (DR + GS) and matching regex.
   # Built once at load time instead of on every logon line.
   ALL_LOGON_PATTERNS = Games::DragonRealms::LOGON_PATTERNS.merge(Games::GemStone::LOGON_PATTERNS).freeze
@@ -95,6 +100,11 @@ class GameTextProcessor
     # Track movement messages to suppress prompts/empty lines after them
     @last_was_movement = false
 
+    # Multi-line gag state: the active { start:, end: } gag being suppressed
+    # (nil when not inside a block) and how many lines it has swallowed so far.
+    @active_multiline_gag = nil
+    @multiline_gag_lines = 0
+
     # Room data tracking for RoomWindow
     @room_capture_mode = nil # :title, :desc, or nil
     @room_pending_title = nil
@@ -136,6 +146,8 @@ class GameTextProcessor
       end
 
       line.chomp!
+
+      next if multiline_gag?(line)
 
       if line.match(GagPatterns.general_regexp)
         next
@@ -273,6 +285,49 @@ class GameTextProcessor
   # @api private
   def append_speech_timestamp(text)
     "#{text} (#{Time.now.strftime('%H:%M:%S').sub(/^0/, '')})"
+  end
+
+  # Decide whether a raw server line should be suppressed as part of a
+  # multi-line gag block, advancing the gag state machine as a side effect.
+  #
+  # When no block is active, the line is tested against the configured
+  # multi-line gag start patterns; a match begins a block and suppresses
+  # the start line. While a block is active every line is suppressed until:
+  #   - the gag's end pattern matches (that end line is also suppressed), or
+  #   - for prompt-terminated gags (no end pattern), a prompt line is seen
+  #     (the prompt is NOT suppressed and passes through normally), or
+  #   - the safety cap is exceeded (the block is released, line passes through).
+  #
+  # @param line [String] raw server line (post-chomp, XML tags intact)
+  # @return [Boolean] true if the line should be dropped
+  # @api private
+  def multiline_gag?(line)
+    if @active_multiline_gag
+      gag = @active_multiline_gag
+      @multiline_gag_lines += 1
+
+      if @multiline_gag_lines > MULTILINE_GAG_MAX_LINES
+        ProfanityLog.write('gag', "multiline gag exceeded #{MULTILINE_GAG_MAX_LINES} lines; releasing")
+        @active_multiline_gag = nil
+        false
+      elsif gag[:end]
+        # Explicit end pattern: the end line is part of the block (suppressed).
+        @active_multiline_gag = nil if line.match?(gag[:end])
+        true
+      elsif line =~ /<prompt\b/
+        # Prompt-terminated: stop gagging and let the prompt line through.
+        @active_multiline_gag = nil
+        false
+      else
+        true
+      end
+    elsif (gag = GagPatterns.match_multiline_start(line))
+      @active_multiline_gag = gag
+      @multiline_gag_lines = 0
+      true
+    else
+      false
+    end
   end
 
   # Emit a prompt to the main stream if one is pending and the last

--- a/lib/settings_loader.rb
+++ b/lib/settings_loader.rb
@@ -89,6 +89,12 @@ module SettingsLoader
         when 'combat_gag'
           GagPatterns.add_combat_pattern(e.text) if e.text && !e.text.strip.empty?
 
+        when 'multiline_gag'
+          start_pattern = e.attributes['start']
+          if start_pattern && !start_pattern.strip.empty?
+            GagPatterns.add_multiline_gag(start_pattern, e.attributes['end'])
+          end
+
         when 'perc-transform'
           if e.attributes['pattern']
             begin

--- a/spec/lib/gag_patterns_spec.rb
+++ b/spec/lib/gag_patterns_spec.rb
@@ -125,6 +125,85 @@ RSpec.describe GagPatterns do
     end
   end
 
+  describe '.add_multiline_gag' do
+    it 'records a start pattern with no end pattern' do
+      described_class.add_multiline_gag('Knowledge from your sanowret crystal')
+      gag = described_class.match_multiline_start('Knowledge from your sanowret crystal about Life Magic')
+      expect(gag).not_to be_nil
+      expect(gag[:end]).to be_nil
+    end
+
+    it 'records a start and end pattern' do
+      described_class.add_multiline_gag('BEGIN block', 'END block')
+      gag = described_class.match_multiline_start('BEGIN block here')
+      expect(gag[:start]).to be_a(Regexp)
+      expect(gag[:end]).to be_a(Regexp)
+      expect('the END block now').to match(gag[:end])
+    end
+
+    it 'treats a blank end pattern as no end pattern' do
+      described_class.add_multiline_gag('start', '   ')
+      gag = described_class.match_multiline_start('start here')
+      expect(gag[:end]).to be_nil
+    end
+
+    it 'accepts Regexp objects for start and end' do
+      described_class.add_multiline_gag(/^Knowledge/, /rings clear/)
+      gag = described_class.match_multiline_start('Knowledge from your crystal')
+      expect(gag).not_to be_nil
+      expect('the knowledge rings clear').to match(gag[:end])
+    end
+
+    it 'warns on invalid start regex and does not add it' do
+      expect {
+        described_class.add_multiline_gag('[unclosed')
+      }.to output(/Invalid multiline gag pattern/).to_stderr
+      expect(described_class.match_multiline_start('[unclosed')).to be_nil
+    end
+
+    it 'accumulates multiple multi-line gags' do
+      described_class.add_multiline_gag('alpha')
+      described_class.add_multiline_gag('beta')
+      expect(described_class.match_multiline_start('alpha line')).not_to be_nil
+      expect(described_class.match_multiline_start('beta line')).not_to be_nil
+    end
+  end
+
+  describe '.match_multiline_start' do
+    it 'returns nil when no multi-line gags are configured' do
+      expect(described_class.match_multiline_start('anything')).to be_nil
+    end
+
+    it 'returns nil for a non-matching line' do
+      described_class.add_multiline_gag('specific start')
+      expect(described_class.match_multiline_start('unrelated text')).to be_nil
+    end
+
+    it 'returns the specific gag whose start matched' do
+      described_class.add_multiline_gag('alpha', 'end-a')
+      described_class.add_multiline_gag('beta', 'end-b')
+      gag = described_class.match_multiline_start('beta arrives')
+      expect('reach end-b').to match(gag[:end])
+      expect('reach end-a').not_to match(gag[:end])
+    end
+  end
+
+  describe '.clear_custom with multi-line gags' do
+    it 'removes multi-line gags' do
+      described_class.add_multiline_gag('start')
+      described_class.clear_custom
+      expect(described_class.match_multiline_start('start here')).to be_nil
+    end
+  end
+
+  describe '.load_defaults with multi-line gags' do
+    it 'clears multi-line gags added before load_defaults' do
+      described_class.add_multiline_gag('start')
+      described_class.load_defaults
+      expect(described_class.match_multiline_start('start here')).to be_nil
+    end
+  end
+
   describe 'Regexp.union behavior edge cases' do
     it 'empty union matches nothing (not everything)' do
       described_class.load_defaults

--- a/spec/lib/game_text_events_spec.rb
+++ b/spec/lib/game_text_events_spec.rb
@@ -264,6 +264,81 @@ RSpec.describe 'GameTextProcessor event emissions' do
     end
   end
 
+  # ---- Multi-line gag state machine ----
+
+  describe 'multi-line gag suppression' do
+    def gag?(line)
+      processor.send(:multiline_gag?, line)
+    end
+
+    def start_block(gag)
+      allow(GagPatterns).to receive(:match_multiline_start) { |line| line =~ /START/ ? gag : nil }
+    end
+
+    it 'passes lines through when no multi-line gag matches' do
+      allow(GagPatterns).to receive(:match_multiline_start).and_return(nil)
+      expect(gag?('ordinary line')).to be false
+    end
+
+    it 'suppresses the start line and begins a block' do
+      start_block({ start: /START/, end: nil })
+      expect(gag?('the START of knowledge')).to be true
+      expect(processor.send(:instance_variable_get, :@active_multiline_gag)).not_to be_nil
+    end
+
+    context 'prompt-terminated block (no end pattern)' do
+      before do
+        start_block({ start: /START/, end: nil })
+        gag?('the START of knowledge')
+      end
+
+      it 'suppresses body lines while active' do
+        expect(gag?('a long paragraph of crystal lore')).to be true
+        expect(gag?('another suppressed line')).to be true
+      end
+
+      it 'releases on a prompt line and lets the prompt through' do
+        gag?('body line')
+        expect(gag?('<prompt time="123">&gt;</prompt>')).to be false
+        expect(processor.send(:instance_variable_get, :@active_multiline_gag)).to be_nil
+      end
+
+      it 'resumes normal processing after the block ends' do
+        gag?('body line')
+        gag?('<prompt time="123">&gt;</prompt>')
+        allow(GagPatterns).to receive(:match_multiline_start).and_return(nil)
+        expect(gag?('back to normal')).to be false
+      end
+    end
+
+    context 'end-pattern block' do
+      before do
+        start_block({ start: /START/, end: /THE END/ })
+        gag?('the START of the block')
+      end
+
+      it 'suppresses lines until the end pattern, inclusive' do
+        expect(gag?('middle line')).to be true
+        expect(gag?('here is THE END of it')).to be true
+        expect(processor.send(:instance_variable_get, :@active_multiline_gag)).to be_nil
+      end
+
+      it 'does not release on a prompt line (only the end pattern ends it)' do
+        expect(gag?('<prompt time="123">&gt;</prompt>')).to be true
+        expect(processor.send(:instance_variable_get, :@active_multiline_gag)).not_to be_nil
+      end
+    end
+
+    it 'releases the block after the safety cap and lets the line through' do
+      start_block({ start: /START/, end: /NEVER MATCHES/ })
+      gag?('the START of a runaway block')
+      GameTextProcessor::MULTILINE_GAG_MAX_LINES.times { gag?('still going') }
+      # The next line exceeds the cap and is released.
+      expect(gag?('one line too many')).to be false
+      expect(processor.send(:instance_variable_get, :@active_multiline_gag)).to be_nil
+    end
+  end
+
   # ---- Highlight application ----
 
   describe 'highlights are applied to routable streams' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -278,6 +278,8 @@ module GagPatterns
   def self.clear_custom = nil
   def self.add_general_pattern(*) = nil
   def self.add_combat_pattern(*) = nil
+  def self.add_multiline_gag(*) = nil
+  def self.match_multiline_start(*) = nil
 end
 
 # ---------------------------------------------------------------------------

--- a/templates/default.xml
+++ b/templates/default.xml
@@ -310,6 +310,17 @@
        ambient actions, lore book text, equipment visual effects, etc.
 
        Format: <gag>REGEX</gag>
+
+       To suppress a whole multi-line block (header + body), use a
+       multi-line gag instead. When a line matches "start", that line and
+       every following line are hidden until "end" matches (also hidden).
+       When "end" is omitted, the block ends at the next game prompt.
+
+       Format: <multiline_gag start="REGEX" end="REGEX"/>
+
+       Example (hides the sanowret crystal header AND its body paragraph,
+       which the single-line gag below cannot do):
+       <multiline_gag start="^Knowledge from your sanowret crystal about .* rings clear in your mind:"/>
   -->
 
   <!-- ==================== YOUR COMBAT ACTIONS ====================

--- a/templates/mahtra.xml
+++ b/templates/mahtra.xml
@@ -426,6 +426,9 @@
   <gag>^You're already playing a song</gag>
   <gag>Assuming you mean (?:a|an) \w+ eddy</gag>
 
+  <!-- Multi-line gags: suppress the header + body block; ends at the prompt -->
+  <multiline_gag start="^Knowledge from your sanowret crystal about .* rings clear in your mind:"/>
+
   <!-- ================================================================
        PERC-TRANSFORM — Text substitutions for the active spells display
        ================================================================

--- a/templates/mahtra.xml
+++ b/templates/mahtra.xml
@@ -426,7 +426,14 @@
   <gag>^You're already playing a song</gag>
   <gag>Assuming you mean (?:a|an) \w+ eddy</gag>
 
-  <!-- Multi-line gags: suppress the header + body block; ends at the prompt -->
+  <!-- ==================== MULTI-LINE GAG PATTERNS ====================
+       Suppress a whole block of lines, not just one. When a line matches
+       "start", that line and every following line are hidden until "end"
+       matches (also hidden), or - if "end" is omitted - until the next
+       game prompt (prompt-terminated). -->
+
+  <!-- sanowret crystal knowledge: header + body paragraph, ends at prompt.
+       Replaces the need to enumerate each lore body line individually. -->
   <multiline_gag start="^Knowledge from your sanowret crystal about .* rings clear in your mind:"/>
 
   <!-- ================================================================


### PR DESCRIPTION
## Summary

Single-line `<gag>`/`<combat_gag>` can only drop one line at a time, so a multi-line message can only be partially hidden. A common example is sanowret crystal knowledge, which arrives as a header line plus a body paragraph, always followed by a prompt:

```
Knowledge from your sanowret crystal about Arcane Magic rings clear in your mind:
There is not sufficient space in this crystal to emphasize how unusual this is. ...
<prompt time="1785038210">&gt;</prompt>
```

A general `<gag>` on the header hides only the first line and leaves the paragraph behind.

This adds a `<multiline_gag>` element that suppresses a whole block:

```xml
<!-- prompt-terminated: hides header + body, ends at the next prompt -->
<multiline_gag start="^Knowledge from your sanowret crystal about .* rings clear in your mind:"/>

<!-- explicit end pattern: end line is also suppressed -->
<multiline_gag start="^You begin to read the tattered scroll\." end="^The scroll crumbles to dust\."/>
```

## Behavior

- `start` (required): when a line matches, that line and every following line are suppressed.
- `end` (optional): the block ends when a line matches `end`; that line is also suppressed.
- When `end` is omitted the block is **prompt-terminated** - it ends at the next game prompt, which is not suppressed.
- A 100-line safety cap releases any block whose `end`/prompt never arrives, so a mistyped pattern cannot swallow the stream.

## Implementation

- `GagPatterns`: `add_multiline_gag` / `match_multiline_start`, with a union-regexp fast-reject so the common no-match path costs a single match. Reset in `load_defaults`/`clear_custom`.
- `SettingsLoader`: parses `<multiline_gag>` on both load and reload.
- `GameTextProcessor`: `multiline_gag?` state machine, checked at the raw-line level before general gags.

## Docs & templates

- `USER_GUIDE.md`: new "Multi-line Gag Patterns" section + examples.
- `templates/default.xml`: commented reference example.
- `templates/mahtra.xml`: live sanowret gag.

## Tests

`rspec` green (822 examples, 0 failures), `rubocop` clean on touched files. New coverage:
- `gag_patterns_spec.rb`: `add_multiline_gag`/`match_multiline_start`, blank-end handling, invalid-regex warning, accumulation, clear/reload reset.
- `game_text_events_spec.rb`: processor state machine - start detection, prompt termination (prompt passes through), end-pattern inclusivity, prompt does not end an end-pattern block, and the safety-cap release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)