### PR TITLE
Exit cleanly on Ctrl+C instead of dumping a backtrace

### DIFF
--- a/lib/application.rb
+++ b/lib/application.rb
@@ -648,6 +648,11 @@ class Application
         end
       end # CursesRenderer.synchronize
     end
+  rescue Interrupt
+    # Ctrl+C: exit cleanly without dumping a backtrace. Interrupt is not a
+    # StandardError, so it bypasses the rescue below; catch it explicitly and
+    # let the ensure block below restore the terminal.
+    nil
   rescue StandardError => e
     ProfanityLog.write('main', e.to_s, backtrace: e.backtrace)
   ensure


### PR DESCRIPTION
## Problem

Closing Profanity with Ctrl+C prints an uncaught-exception backtrace before exiting, e.g.:

```
lib/application.rb:612:in 'IO.select': Interrupt
        from lib/application.rb:612:in 'block in Application#input_loop'
        from lib/application.rb:611:in 'Application#input_loop'
        from lib/application.rb:97:in 'Application#run'
        from profanity.rb:292:in '<main>'
```

## Cause

Ctrl+C raises `Interrupt` at whatever line is currently executing, which is almost always the `IO.select([$stdin], nil, nil, 0.1)` blocking call in `input_loop`. `Interrupt < SignalException < Exception` -- it is **not** a `StandardError`, so it bypasses the existing `rescue StandardError` in `input_loop` and propagates to `<main>`, where Ruby's default handler prints the backtrace.

## Fix

Catch `Interrupt` explicitly in `input_loop` so it falls through to the existing `ensure` block, which closes the server socket and restores the terminal via `Curses.close_screen`. The process now exits cleanly with no trace.

## Testing

Launched Profanity and pressed Ctrl+C: terminal is restored as before and no backtrace is printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)