### PR TITLE
Restore enclosing stream on popStream instead of clearing to main

### DIFF
--- a/lib/game_text_processor.rb
+++ b/lib/game_text_processor.rb
@@ -11,6 +11,7 @@ require_relative 'xml_tokenizer'
 require_relative 'tag_handlers'
 require_relative 'styled_text'
 require_relative 'event_bus'
+require_relative 'stream_stack'
 
 # Processes game server output in a dedicated thread, handling XML tag parsing,
 # stream routing, room data assembly, spell abbreviation, and UI updates.
@@ -84,8 +85,12 @@ class GameTextProcessor
     @open_color = []
     @open_link = []
 
-    # Stream and display state
+    # Stream and display state.
+    # @current_stream is the active stream (nil routes to the main window);
+    # @stream_stack holds the enclosing streams suspended while nested streams
+    # are open so a popStream restores the parent instead of clearing to main.
     @current_stream = nil
+    @stream_stack = StreamStack.new
     @bold_next_line = false
     @emptycount = 0
     @combat_next_line = nil

--- a/lib/stream_stack.rb
+++ b/lib/stream_stack.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Tracks streams suspended by stream nesting in the game protocol.
+#
+# GemStone and DragonRealms wrap side-channel output in
+# +<pushStream id="..."/>+ ... +<popStream/>+ pairs, and those pairs nest:
+# a room component can open while a speech stream is active, and an
+# asynchronous script (for example moonwatch repainting the +moonWindow+
+# side stream) can inject its own push/pop between a game stream's open and
+# close. The frontend routes output to a single *active* stream, but on
+# +popStream+ it must restore the *enclosing* stream rather than always
+# falling back to the main window. A scalar "current stream" cannot express
+# that nesting, so a +popStream+ closing an inner stream resets routing to
+# the main window and the enclosing stream's remaining text leaks there (or,
+# symmetrically, a stray inner pop leaves the outer window "stuck" with
+# content that was meant for another window).
+#
+# StreamStack is the stack of enclosing streams that have been *suspended*
+# while a nested stream is active. The caller owns the active stream itself:
+# on open it {#push}es the stream being suspended, and on close it {#pop}s to
+# recover the stream to resume. A +nil+ entry represents the main window (no
+# active stream), so a stream opened directly from the main window restores
+# correctly to the main window when it closes.
+#
+# @example Restore the enclosing stream on close
+#   stack   = StreamStack.new
+#   current = 'thoughts'   # the active stream
+#   stack.push(current)    # a nested stream opens, suspending 'thoughts'...
+#   current = 'moonWindow' # ...and 'moonWindow' becomes active
+#   current = stack.pop    # the nested stream closes -> resume 'thoughts'
+#   #=> 'thoughts' (not nil)
+#
+# @example An unmatched pop is safe
+#   StreamStack.new.pop #=> nil (the main window)
+class StreamStack
+  # Create an empty stack with no suspended streams.
+  #
+  # @return [StreamStack]
+  def initialize
+    @suspended = []
+  end
+
+  # Suspend a stream because a nested stream is opening.
+  #
+  # @param stream [String, nil] the stream being suspended; +nil+ denotes the
+  #   main window (i.e. a stream opened while no other stream was active)
+  # @return [String, nil] the stream just suspended (the argument), for chaining
+  def push(stream)
+    @suspended.push(stream)
+    stream
+  end
+
+  # Resume the most recently suspended stream.
+  #
+  # Popping an empty stack yields +nil+ (the main window) rather than raising,
+  # so an unmatched +popStream+ can never crash the parser.
+  #
+  # @return [String, nil] the stream to resume, or +nil+ for the main window
+  def pop
+    @suspended.pop
+  end
+
+  # Peek at the stream that would be resumed next, without removing it.
+  #
+  # @return [String, nil] the top suspended stream, or +nil+ if none are suspended
+  def peek
+    @suspended.last
+  end
+
+  # @return [Integer] the number of currently suspended streams (nesting depth)
+  def depth
+    @suspended.length
+  end
+
+  # @return [Boolean] whether any streams are suspended
+  def empty?
+    @suspended.empty?
+  end
+
+  # Discard every suspended stream, e.g. on a hard routing reset.
+  #
+  # @return [void]
+  def reset
+    @suspended.clear
+  end
+end

--- a/lib/tag_handlers.rb
+++ b/lib/tag_handlers.rb
@@ -14,7 +14,8 @@ require_relative 'link_extractor'
 # - @wm, @state, @cmd_buffer, @xml_escapes, @event_bus
 # - @line_colors, @open_monsterbold, @open_preset, @open_style,
 #   @open_color, @open_link
-# - @current_stream, @combat_next_line, @need_update, @need_room_render
+# - @current_stream, @stream_stack, @combat_next_line, @need_update,
+#   @need_room_render
 # - @room_capture_mode
 # - handle_game_text, new_stun, fix_layout_number, parse_room_subtitle,
 #   add_prompt
@@ -347,11 +348,17 @@ module TagHandlers
   end
 
   # Handle <pushStream>, <component>, or <compDef> stream-opening tag.
-  # Flushes accumulated text and switches the current stream.
+  #
+  # Flushes accumulated text, suspends the stream that was active by pushing
+  # it onto {StreamStack}, and switches to the newly opened stream. Suspending
+  # the previous stream (rather than discarding it) lets {#handle_stream_close}
+  # restore it when this nested stream closes, so nested/asynchronously-injected
+  # streams do not strand the enclosing stream's text in the wrong window.
   def handle_stream_open(xml, text_buffer)
     return unless (m = xml.match(%r{id=(?<q>"|')(?<id>.*?)\k<q>}))
 
     flush_text_buffer(text_buffer)
+    @stream_stack.push(@current_stream)
     new_stream = m[:id]
     if (exp_match = new_stream.match(/^exp (?<skill>\w+\s?\w+?)/))
       @current_stream = 'exp'
@@ -371,7 +378,12 @@ module TagHandlers
   end
 
   # Handle <popStream.../>, </component>, or </compDef> stream-closing tag.
-  # Flushes accumulated text and clears the current stream.
+  #
+  # Flushes accumulated text and resumes the enclosing stream that was
+  # suspended by the matching {#handle_stream_open} (via {StreamStack#pop}),
+  # falling back to the main window (+nil+) when nothing is suspended. This
+  # replaces the previous unconditional reset to the main window, which caused
+  # a nested or asynchronously-injected pop to close the wrong stream.
   def handle_stream_close(_xml, text_buffer)
     if text_buffer.empty? && @current_stream&.start_with?('room')
       # Empty room components (e.g., <component id='room players'></component>)
@@ -388,7 +400,7 @@ module TagHandlers
       flush_text_buffer(text_buffer)
     end
     @event_bus.emit(:exp_delete_skill) if @current_stream == 'exp'
-    @current_stream = nil
+    @current_stream = @stream_stack.pop
   end
 
   # Handle <clearStream id="percWindow"/> tag.

--- a/spec/lib/stream_stack_spec.rb
+++ b/spec/lib/stream_stack_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# Tests StreamStack: the stack of enclosing streams suspended while nested
+# game-output streams are active. Covers push/pop LIFO ordering, the nil
+# "main window" entry, peek/depth/empty?/reset, and the adversarial cases
+# that matter for stream routing (unmatched pop, deep nesting, repeated
+# reset), plus an end-to-end mirror of the moon-window leak scenario.
+
+require_relative '../../lib/stream_stack'
+
+RSpec.describe StreamStack do
+  subject(:stack) { described_class.new }
+
+  describe 'a freshly created stack' do
+    it 'is empty' do
+      expect(stack.empty?).to be true
+    end
+
+    it 'has zero depth' do
+      expect(stack.depth).to eq 0
+    end
+
+    it 'peeks nil' do
+      expect(stack.peek).to be_nil
+    end
+
+    it 'pops nil without raising' do
+      expect(stack.pop).to be_nil
+    end
+  end
+
+  describe '#push' do
+    it 'returns the stream it suspended' do
+      expect(stack.push('thoughts')).to eq 'thoughts'
+    end
+
+    it 'increases the depth by one' do
+      expect { stack.push('thoughts') }.to change(stack, :depth).from(0).to(1)
+    end
+
+    it 'makes the pushed stream the next one to resume' do
+      stack.push('thoughts')
+      expect(stack.peek).to eq 'thoughts'
+    end
+
+    it 'accepts nil to represent the main window' do
+      stack.push(nil)
+      expect(stack.depth).to eq 1
+      expect(stack.peek).to be_nil
+    end
+  end
+
+  describe '#pop' do
+    it 'returns the most recently suspended stream' do
+      stack.push('thoughts')
+      expect(stack.pop).to eq 'thoughts'
+    end
+
+    it 'removes the stream so it is not resumed twice' do
+      stack.push('thoughts')
+      stack.pop
+      expect(stack.empty?).to be true
+    end
+
+    it 'resumes suspended streams in last-in-first-out order' do
+      stack.push('speech')
+      stack.push('room')
+      expect(stack.pop).to eq 'room'
+      expect(stack.pop).to eq 'speech'
+    end
+
+    it 'resumes the main window (nil) for a stream that was opened from main' do
+      stack.push(nil) # a stream opened while nothing else was active
+      expect(stack.pop).to be_nil
+    end
+  end
+
+  describe '#peek' do
+    it 'reports the next stream to resume without removing it' do
+      stack.push('familiar')
+      expect(stack.peek).to eq 'familiar'
+      expect(stack.depth).to eq 1
+    end
+  end
+
+  describe '#reset' do
+    it 'discards every suspended stream' do
+      stack.push('speech')
+      stack.push('room')
+      stack.reset
+      expect(stack.empty?).to be true
+      expect(stack.peek).to be_nil
+    end
+  end
+
+  # ==================================================================
+  # Adversarial edge cases
+  # ==================================================================
+
+  describe 'adversarial: underflow' do
+    it 'keeps returning nil when popped past empty' do
+      stack.push('thoughts')
+      expect(stack.pop).to eq 'thoughts'
+      expect(stack.pop).to be_nil
+      expect(stack.pop).to be_nil
+      expect(stack.depth).to eq 0
+    end
+  end
+
+  describe 'adversarial: deep nesting' do
+    it 'unwinds a deep stack in exact reverse order' do
+      ids = %w[a b c d e f g h]
+      ids.each { |id| stack.push(id) }
+      expect(stack.depth).to eq ids.length
+      expect(ids.length.times.map { stack.pop }).to eq ids.reverse
+      expect(stack.empty?).to be true
+    end
+  end
+
+  describe 'adversarial: repeated reset' do
+    it 'is idempotent and safe on an already-empty stack' do
+      stack.reset
+      expect { stack.reset }.not_to raise_error
+      expect(stack.empty?).to be true
+    end
+  end
+
+  describe 'the moon-window leak scenario' do
+    # Mirrors what happens when moonwatch (an async script) repaints the moon
+    # window while the game has a familiar stream open: the injected stream
+    # must close back to 'familiar', never to the main window.
+    it 'restores the active game stream after an injected side stream closes' do
+      active = 'familiar'         # game stream currently active
+      stack.push(active)          # async side stream opens, suspending 'familiar'
+      active = 'moonWindow'       # the injected moon-window stream is now active
+      expect(active).to eq 'moonWindow'
+      active = stack.pop          # the side stream closes
+      expect(active).to eq 'familiar'
+      expect(stack.empty?).to be true
+    end
+  end
+end

--- a/spec/lib/tag_handlers_spec.rb
+++ b/spec/lib/tag_handlers_spec.rb
@@ -7,6 +7,7 @@
 
 require_relative '../../lib/event_bus'
 require_relative '../../lib/xml_tokenizer'
+require_relative '../../lib/stream_stack'
 require_relative '../../lib/tag_handlers'
 
 # Minimal host class that includes TagHandlers, providing the instance
@@ -18,7 +19,7 @@ class TagHandlerHost
                 :open_color, :open_link, :current_stream, :combat_next_line,
                 :need_update, :need_room_render, :room_capture_mode
 
-  attr_reader :flushed_texts, :wm, :state, :cmd_buffer, :event_bus
+  attr_reader :flushed_texts, :wm, :state, :cmd_buffer, :event_bus, :stream_stack
 
   def initialize(wm:, state:, event_bus:)
     @wm = wm
@@ -33,6 +34,7 @@ class TagHandlerHost
     @open_color = []
     @open_link = []
     @current_stream = nil
+    @stream_stack = StreamStack.new
     @combat_next_line = nil
     @need_update = false
     @need_room_render = false
@@ -741,15 +743,66 @@ RSpec.describe TagHandlers do
       expect(host.current_stream).to eq 'thoughts'
     end
 
-    it 'stream close after multiple opens resets to nil' do
+    it 'stream close after nested opens restores the enclosing stream' do
+      # A popStream closes only the innermost stream; the parent must resume
+      # so its remaining text keeps routing to the right window instead of
+      # spilling into the main window.
       host.dispatch_tag('<pushStream id="combat" />', String.new)
       host.dispatch_tag('<pushStream id="thoughts" />', String.new)
       host.dispatch_tag('<popStream/>', String.new)
-      expect(host.current_stream).to be_nil
+      expect(host.current_stream).to eq 'combat'
     end
 
     it 'clearStream for non-percWindow id does not crash' do
       expect { host.dispatch_tag('<clearStream id="other"/>', String.new) }.not_to raise_error
+    end
+  end
+
+  # Regression coverage for the "text leaks into another window" class of bug:
+  # a nested or asynchronously-injected stream (e.g. moonwatch repainting the
+  # moon window) must not close the game stream that was already active.
+  describe 'nested stream restoration' do
+    it 'restores the main window (nil) after a single balanced open/close' do
+      host.dispatch_tag('<pushStream id="moonWindow" />', String.new)
+      expect(host.current_stream).to eq 'moonWindow'
+      host.dispatch_tag('<popStream/>', String.new)
+      expect(host.current_stream).to be_nil
+    end
+
+    it 'restores the enclosing game stream when an injected stream closes' do
+      host.dispatch_tag('<pushStream id="familiar" />', String.new)
+      # An asynchronous script pushes its own self-contained stream inside the
+      # still-open familiar stream, then pops it.
+      host.dispatch_tag('<pushStream id="moonWindow" />', String.new)
+      host.dispatch_tag('<popStream/>', String.new)
+      expect(host.current_stream).to eq 'familiar'
+    end
+
+    it 'unwinds several nesting levels back to the main window in order' do
+      %w[thoughts room moonWindow].each { |id| host.dispatch_tag(%(<pushStream id="#{id}" />), String.new) }
+      expect(host.current_stream).to eq 'moonWindow'
+      host.dispatch_tag('<popStream/>', String.new)
+      expect(host.current_stream).to eq 'room'
+      host.dispatch_tag('<popStream/>', String.new)
+      expect(host.current_stream).to eq 'thoughts'
+      host.dispatch_tag('<popStream/>', String.new)
+      expect(host.current_stream).to be_nil
+    end
+
+    it 'treats </component> and </compDef> as stream closes that restore the parent' do
+      host.dispatch_tag('<pushStream id="speech" />', String.new)
+      host.dispatch_tag('<component id="room objs">', String.new)
+      expect(host.current_stream).to eq 'room objs'
+      host.dispatch_tag('</component>', String.new)
+      expect(host.current_stream).to eq 'speech'
+    end
+
+    it 'never underflows: extra popStreams stay at the main window' do
+      host.dispatch_tag('<pushStream id="thoughts" />', String.new)
+      3.times { host.dispatch_tag('<popStream/>', String.new) }
+      expect(host.current_stream).to be_nil
+      expect { host.dispatch_tag('<popStream/>', String.new) }.not_to raise_error
+      expect(host.current_stream).to be_nil
     end
   end
 


### PR DESCRIPTION
Stream routing tracked the active stream with a single scalar that popStream always reset to nil (the main window). The GemStone/DR protocol nests streams, and asynchronous scripts (e.g. moonwatch repainting the moonWindow side stream) can inject a push/pop between a game stream's open and close. With a scalar pointer, that inner popStream closed the *outer* game stream, so its remaining text spilled into the main window and, in the reverse case, foreign content was stranded in the wrong window.

Add StreamStack: the stack of enclosing streams suspended while a nested stream is active. handle_stream_open pushes the previously active stream; handle_stream_close pops to resume it, falling back to the main window (nil) only when nothing is suspended. Unmatched pops can never underflow.

@current_stream keeps its role as the active stream, so all existing read sites are unchanged; only open/close mutate the nesting. Adds a StreamStack unit spec and nested-restoration coverage in the tag handler spec, and updates the one prior spec that asserted the old clear-to-nil behavior.