### PR TITLE
fix: strip trailing bracket from room-window title (no more "]]")

### DIFF
--- a/lib/room_data_processor.rb
+++ b/lib/room_data_processor.rb
@@ -60,7 +60,12 @@ module RoomDataProcessor
       room_title = parse_room_subtitle(text)
       @state.room_title = room_title unless room_title.empty?
       if @wm.room['room']
-        @room_pending_title = text.sub(/^\[/, '').sub(/\]\s*\(/, ' (').strip
+        # Strip the title's brackets so RoomWindow#render can re-add them exactly once.
+        # The closing bracket takes two forms: "[Room] (230008)" (RealID appended, the
+        # bracket precedes the "(") and "[Room - 2071]" or plain "[Room]" (no RealID, the
+        # bracket is trailing). Handle the trailing case too - dropping only the "] (" form
+        # left the trailing "]" behind, which render then doubled into "[Room - 2071]]".
+        @room_pending_title = text.sub(/^\[/, '').sub(/\]\s*\(/, ' (').sub(/\]\s*\z/, '').strip
         @room_pending_title_colors = line_colors.dup
         room_data_captured = true
       end

--- a/spec/lib/room_data_processor_spec.rb
+++ b/spec/lib/room_data_processor_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Tests RoomDataProcessor#process_room_data's room-title capture (the :title mode).
+#
+# The RoomWindow re-brackets whatever bare title it is handed (see
+# RoomWindow#render: "[#{@title}]"), so process_room_data must hand it a title
+# with ITS OWN brackets already stripped. The tricky part is that the game's
+# closing bracket appears in two shapes: "[Room] (230008)" (a RealID follows the
+# bracket) and "[Room - 2071]" / "[Room]" (the bracket is trailing). Missing the
+# trailing case leaves a stray "]" that render then doubles into "]]".
+
+require_relative '../../lib/event_bus'
+require_relative '../../lib/room_data_processor'
+
+# Minimal host that includes RoomDataProcessor and supplies only the collaborators
+# #process_room_data touches in :title mode: a room-window presence check, a
+# writable room_title on shared state, and the parse_room_subtitle helper that
+# lives on GameTextProcessor in production.
+class RoomTitleHost
+  include RoomDataProcessor
+
+  attr_accessor :room_capture_mode, :room_pending_title, :room_pending_title_colors,
+                :current_stream, :current_raw_line, :line_colors
+  attr_reader :wm, :state
+
+  # @param has_room_window [Boolean] whether the layout has a RoomWindow (only
+  #   then is the pending title captured)
+  def initialize(has_room_window: true)
+    @event_bus = EventBus.new
+    @wm = Struct.new(:room).new(has_room_window ? { 'room' => Object.new } : {})
+    @state = Struct.new(:room_title).new(nil)
+    @room_capture_mode = :title
+    @room_pending_title = nil
+    @room_pending_title_colors = nil
+    @current_stream = nil
+    @current_raw_line = nil
+    @line_colors = []
+  end
+
+  # Mirror of GameTextProcessor#parse_room_subtitle (strips the " - " prefix and
+  # the outer brackets), used here for the terminal-title assignment side of the
+  # method. Kept identical so the spec exercises the real capture logic.
+  def parse_room_subtitle(subtitle)
+    text = subtitle.sub(/^\s*-\s*/, '')
+    text.sub(/^\[(.+?)\]/, '\1').strip
+  end
+end
+
+RSpec.describe RoomDataProcessor do
+  describe '#process_room_data room title capture (:title mode)' do
+    subject(:host) { RoomTitleHost.new }
+
+    # Captures the bare (bracket-stripped) title RoomWindow#render will re-bracket.
+    # @param text [String] the roomName styled text as sent by the game/Lich
+    # @return [String, nil] the captured @room_pending_title
+    def capture(text)
+      host.room_capture_mode = :title
+      host.process_room_data(text, [])
+      host.room_pending_title
+    end
+
+    it 'strips the brackets and keeps the RealID when the game appends one' do
+      expect(capture('[Bosque Deriel, Hermit\'s Shacks] (230008)'))
+        .to eq('Bosque Deriel, Hermit\'s Shacks (230008)')
+    end
+
+    it 'strips a trailing bracket when the title carries a lich id but no RealID' do
+      # BUG (fixed): the old ".sub(/\\]\\s*\\(/, ' (')" only removed the bracket
+      # before a "(", so "[Room - 2071]" kept its "]" and render produced "]]".
+      expect(capture('[Bosque Deriel, Hermit\'s Shacks - 2071]'))
+        .to eq('Bosque Deriel, Hermit\'s Shacks - 2071')
+    end
+
+    it 'strips a trailing bracket for a plain title with no id at all' do
+      expect(capture('[Town Square]')).to eq('Town Square')
+    end
+
+    it 'keeps both the lich id and the RealID (GS-parity title from Lich)' do
+      expect(capture('[Bosque Deriel, Hermit\'s Shacks - 2071] (230008)'))
+        .to eq('Bosque Deriel, Hermit\'s Shacks - 2071 (230008)')
+    end
+
+    it 'leaves no bracket that RoomWindow#render would double into "]]"' do
+      %w([Room] [Room-2071] [Room](5)).each do |sample|
+        expect(capture(sample)).not_to include(']')
+      end
+    end
+
+    it 'preserves interior punctuation while stripping only the outer brackets' do
+      expect(capture('[Warrens, Alcove - 1234]')).to eq('Warrens, Alcove - 1234')
+    end
+
+    it 'does not capture a pending title when the layout has no RoomWindow' do
+      windowless = RoomTitleHost.new(has_room_window: false)
+      windowless.room_capture_mode = :title
+      windowless.process_room_data('[Town Square]', [])
+      expect(windowless.room_pending_title).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`RoomDataProcessor#process_room_data` captured the room-window title with:

```ruby
@room_pending_title = text.sub(/^\[/, '').sub(/\]\s*\(/, ' (').strip
```

That removes the leading `[` unconditionally, but only removes the closing `]` when it is immediately followed by a `(` — i.e. the `[Room] (230008)` RealID form. A bracketed title **without** a trailing `(number)` keeps its `]`:

- `[Bosque Deriel, Hermit's Shacks - 2071]` — Lich's `;display lichid` + `;display roomid title` when the game RealID isn't appended → `Bosque Deriel, Hermit's Shacks - 2071]`
- `[Town Square]` — any plain room → `Town Square]`

`RoomWindow#render` then re-brackets the title (`"[#{@title}]"`), doubling the stray bracket into **`[Bosque Deriel, Hermit's Shacks - 2071]]`**.

(Surfaced while chasing a doubled `]` alongside elanthia-online/lich-5#1500; that Lich PR fixes the DR side by preserving the game RealID, but this front-end regex is independently buggy for any bracketed title lacking a trailing `(number)`.)

## Fix

Also strip a trailing `]`, so the captured title is always bracket-free regardless of whether the game appended a RealID:

```ruby
@room_pending_title = text.sub(/^\[/, '').sub(/\]\s*\(/, ' (').sub(/\]\s*\z/, '').strip
```

`render` then adds exactly one pair of brackets.

| input (roomName text) | captured title | rendered |
|---|---|---|
| `[Room] (230008)` | `Room (230008)` | `[Room] (230008)` |
| `[Room - 2071]` | `Room - 2071` | `[Room - 2071]` (was `[Room - 2071]]`) |
| `[Town Square]` | `Town Square` | `[Town Square]` (was `[Town Square]]`) |
| `[Room - 2071] (230008)` | `Room - 2071 (230008)` | `[Room - 2071] (230008)` |

## Tests

New `spec/lib/room_data_processor_spec.rb` drives `#process_room_data` in `:title` mode over the RealID, lich-id-only, plain, and combined title shapes, plus adversarial "leaves no stray `]`" and no-RoomWindow cases.

Full suite green: **852 examples, 0 failures**; `rubocop` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)