### PR TITLE
Fix cursor_backspace_word/delete_word/yank not repainting until next keystroke

### DIFF
--- a/lib/application.rb
+++ b/lib/application.rb
@@ -427,6 +427,20 @@ class Application
 
   # ---- Key action setup ----
 
+  # Register every named key action as a {Proc} in {#key_action}.
+  #
+  # Each cursor/edit action delegates to {CommandBuffer}, which only stages
+  # its changes to the curses virtual screen via +noutrefresh+. The physical
+  # terminal is not repainted until +doupdate+ is called, so *every* action
+  # that mutates the visible command line must end with
+  # {CursesRenderer.doupdate}. Omitting it leaves the edit invisible until
+  # the next keystroke happens to trigger a flush -- the class of bug that
+  # previously affected +cursor_backspace_word+, +cursor_delete_word+, and
+  # +cursor_yank+.
+  #
+  # @return [void]
+  # @see CommandBuffer#backspace_word
+  # @see CursesRenderer.doupdate
   def setup_key_actions
     @key_action['resize'] = proc {
       @window_mgr.resize(@cmd_buffer)
@@ -441,11 +455,11 @@ class Application
     @key_action['cursor_end']            = proc { @cmd_buffer.cursor_end; CursesRenderer.doupdate }
     @key_action['cursor_backspace']      = proc { @cmd_buffer.backspace; CursesRenderer.doupdate }
     @key_action['cursor_delete']         = proc { @cmd_buffer.delete_char; CursesRenderer.doupdate }
-    @key_action['cursor_backspace_word'] = proc { @cmd_buffer.backspace_word }
-    @key_action['cursor_delete_word']    = proc { @cmd_buffer.delete_word }
+    @key_action['cursor_backspace_word'] = proc { @cmd_buffer.backspace_word; CursesRenderer.doupdate }
+    @key_action['cursor_delete_word']    = proc { @cmd_buffer.delete_word; CursesRenderer.doupdate }
     @key_action['cursor_kill_forward']   = proc { @cmd_buffer.kill_forward; CursesRenderer.doupdate }
     @key_action['cursor_kill_line']      = proc { @cmd_buffer.kill_line; CursesRenderer.doupdate }
-    @key_action['cursor_yank']           = proc { @cmd_buffer.yank }
+    @key_action['cursor_yank']           = proc { @cmd_buffer.yank; CursesRenderer.doupdate }
 
     @key_action['switch_current_window'] = proc {
       SCROLL_WINDOW[0]&.set_active(false)

--- a/spec/lib/application_spec.rb
+++ b/spec/lib/application_spec.rb
@@ -318,6 +318,83 @@ RSpec.describe Application do
     end
   end
 
+  # ---- Regression: editing key actions must flush the physical screen ----
+  #
+  # CommandBuffer edits only stage changes to the curses virtual screen
+  # (via noutrefresh). Nothing appears on the terminal until doupdate is
+  # called. Every key action that mutates the visible command line must
+  # therefore end with CursesRenderer.doupdate, otherwise the edit stays
+  # invisible until the next keystroke happens to trigger a flush.
+  #
+  # BUG FOUND (fixed here): cursor_backspace_word, cursor_delete_word, and
+  # cursor_yank omitted the doupdate call, so word-delete and yank appeared
+  # to "do nothing" until the user typed the next character.
+  describe 'editing key actions flush with doupdate' do
+    before do
+      app.cmd_buffer.window = Curses::Window.new(1, 80, 0, 0)
+    end
+
+    # Every action listed here mutates the visible line and MUST repaint.
+    editing_actions = %w[
+      cursor_left cursor_right cursor_word_left cursor_word_right
+      cursor_home cursor_end cursor_backspace cursor_delete
+      cursor_backspace_word cursor_delete_word cursor_kill_forward
+      cursor_kill_line cursor_yank
+    ]
+
+    editing_actions.each do |action|
+      it "#{action} calls CursesRenderer.doupdate" do
+        expect(CursesRenderer).to receive(:doupdate)
+        app.key_action[action].call
+      end
+    end
+
+    # ---- The three previously-broken actions, tested behaviorally ----
+
+    it 'cursor_backspace_word deletes the previous word and repaints' do
+      app.do_macro('hello world')
+      expect(CursesRenderer).to receive(:doupdate)
+      app.key_action['cursor_backspace_word'].call
+      expect(app.cmd_buffer.text).to eq 'hello '
+    end
+
+    it 'cursor_delete_word deletes the next word and repaints' do
+      app.do_macro('hello world')
+      app.cmd_buffer.cursor_home
+      expect(CursesRenderer).to receive(:doupdate)
+      app.key_action['cursor_delete_word'].call
+      expect(app.cmd_buffer.text).to eq ' world'
+    end
+
+    it 'cursor_yank restores killed text and repaints' do
+      app.do_macro('hello')
+      app.key_action['cursor_kill_line'].call # fills the kill ring, clears line
+      expect(app.cmd_buffer.text).to eq ''
+      expect(CursesRenderer).to receive(:doupdate)
+      app.key_action['cursor_yank'].call
+      expect(app.cmd_buffer.text).to eq 'hello'
+    end
+
+    # ---- Adversarial: no-op edits must still flush ----
+    #
+    # A word-delete on an empty buffer changes nothing, but the action must
+    # not silently skip doupdate -- the invariant is "always repaint after an
+    # edit action", regardless of whether the buffer actually changed.
+
+    it 'cursor_backspace_word on an empty buffer still calls doupdate' do
+      expect(app.cmd_buffer.text).to eq ''
+      expect(CursesRenderer).to receive(:doupdate)
+      app.key_action['cursor_backspace_word'].call
+    end
+
+    it 'cursor_yank with an empty kill ring still calls doupdate' do
+      expect(app.cmd_buffer.text).to eq ''
+      expect(CursesRenderer).to receive(:doupdate)
+      app.key_action['cursor_yank'].call
+      expect(app.cmd_buffer.text).to eq ''
+    end
+  end
+
   # ---- Feedback colors ----
 
   describe 'feedback_colors' do


### PR DESCRIPTION
## Problem

`cursor_backspace_word`, `cursor_delete_word`, and `cursor_yank` mutate the command buffer — which only stages changes to the curses *virtual* screen via `noutrefresh` — but never call `CursesRenderer.doupdate`. Since `doupdate` is what flushes the virtual screen to the physical terminal, these edits stay invisible until the next keystroke happens to trigger a flush.

The user-visible symptom: `cursor_backspace` and `cursor_kill_line` take effect immediately, but `cursor_backspace_word` (and word-delete / yank) "only take effect when you type something."

## Fix

Append `CursesRenderer.doupdate` to all three key-action procs in `setup_key_actions`, so they repaint immediately — matching every other cursor/edit action (`cursor_backspace`, `cursor_kill_line`, etc.). Added YARD on `setup_key_actions` documenting the invariant: any action that mutates the visible command line must end with `doupdate`.

```ruby
# before
@key_action['cursor_backspace_word'] = proc { @cmd_buffer.backspace_word }
# after
@key_action['cursor_backspace_word'] = proc { @cmd_buffer.backspace_word; CursesRenderer.doupdate }
```

## Tests

Added a regression block to `spec/lib/application_spec.rb`:
- every editing key action asserts it calls `CursesRenderer.doupdate`;
- behavioral tests for the three fixed actions (word deleted / yank restored *and* screen flushed);
- adversarial no-op cases (word-delete on empty buffer, yank with empty kill ring) still flush.

Verified the new specs **fail against the pre-fix code** (8 failures, exactly the three actions) and pass with the fix.

- Touched-file specs: `66 examples, 0 failures`
- Full suite: `847 examples, 0 failures`
- `rubocop lib/application.rb spec/lib/application_spec.rb`: `no offenses detected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)